### PR TITLE
Disable remote matrix file checking when lookup in cache

### DIFF
--- a/docs/release_notes/version_0.3_updates.rst
+++ b/docs/release_notes/version_0.3_updates.rst
@@ -2,6 +2,14 @@ Version 0.3 Updates
 /////////////////////////
 
 
+Version 0.3.2
+===============
+
+Fixes
+++++++++++++++++
+- fixed issue when  reading an interpolation matrix from the cache unnecessarily invoked checking of remote matrix files on download server
+
+
 Version 0.3.1
 ===============
 

--- a/earthkit/regrid/utils/caching.py
+++ b/earthkit/regrid/utils/caching.py
@@ -46,8 +46,8 @@ SETTINGS = {
     "maximum-cache-size": 5 * 1024 * 1024 * 1024,
     "maximum-cache-disk-usage": 99,
     "url-download-timeout": 30,
-    "check-out-of-date-urls": True,
-    "download-out-of-date-urls": True,
+    "check-out-of-date-urls": False,
+    "download-out-of-date-urls": False,
     "temporary-cache-directory-root": None,
 }
 


### PR DESCRIPTION
This PR fixes an issue when calling `interpolate()` and reading an interpolation matrix from the cache  unnecessarily invoked the checking of remote matrix files on the download server (get.ecwmf.int). This check is executed by calling  `HTTPDownloaderBase.out_of_date()` from `multiurl`, which sends a head request to the download server and compares the result to the cached metadata. However, `out_of_date()` always returns False due to the settings of the download server, so this check is unnecessary and just puts extra burden on the download server. 

The check is disabled now. When needed the option triggering it can be exposed to the users either as a kwarg to `interpolate()` or as a settings (yet to be implemented).
