### PR TITLE
Add nnz and matrix memory size to index

### DIFF
--- a/tools/manage/build_db.py
+++ b/tools/manage/build_db.py
@@ -102,7 +102,7 @@ out_grids = {
     "O_rgg": [400],
 }
 
-build_root_dir = "_build_20241021"
+build_root_dir = "_build_20241123"
 build_dir = os.path.join(build_root_dir, "db")
 
 # extra = [["0.25x0.25", "N320"], ["O1280", "N320"], ["5x5", "10x10"]]
@@ -115,7 +115,7 @@ LOG.debug(f"{out_grids=}")
 
 index_file = os.path.join(build_dir, "index.json")
 
-for method in ["grid-box-average"]:  # ["linear", "nn", "grid-box-average"]:
+for method in ["linear", "nn", "grid-box-average"]:
     matrix_dir = os.path.join(build_dir, f"matrices_{method}")
 
     for g_in in in_grids:


### PR DESCRIPTION
With this PR a given matrix entry in the index file contains two additional keys:

- nnz: number of nonzero elements in the sparse matrix
- memory: the estimated size (in bytes) of the matrix in memory when loaded with `scipy.sparse.load_npz()`

This information will be used to estimate the matrix size before loading. It will be utilised in the yet to be added in memory matrix cache.