### PR TITLE
Cannot free chache space due to sqlite row assignment error

### DIFF
--- a/src/earthkit/regrid/utils/caching.py
+++ b/src/earthkit/regrid/utils/caching.py
@@ -373,13 +373,10 @@ class CacheManager(threading.Thread):
             except OSError:
                 pass
 
-        if entry["size"] is None:
-            entry["size"] = 0
-
-        path, size = (
-            entry["path"],
-            entry["size"],
-        )
+        path = entry["path"]
+        size = entry["size"]
+        if size is None:
+            size = 0
 
         # path, size, owner, args = (
         #     entry["path"],


### PR DESCRIPTION
This PR fixes the issue when cache disk space could not be freed up due to the following error:

`TypeError: 'sqlite3.Row' object does not support item assignment`