### PR TITLE
Improve orca gridspec checks

### DIFF
--- a/src/earthkit/regrid/gridspec.py
+++ b/src/earthkit/regrid/gridspec.py
@@ -20,7 +20,8 @@ DEGREE_EPS = 1e-8
 
 HEALPIX_PATTERN = re.compile(r"[Hh]\d+")
 RGG_PATTERN = re.compile(r"[OoNn]\d+")
-ORCA_PATTERN = re.compile(r"eORCA\d+_[TUVW]")
+ORCA_PATTERN = re.compile(r"^e?ORCA\d+_[FTUV]$")
+
 
 # NOTE: this is a temporary code until the full gridspec
 # implementation is available via earthkit-geo.

--- a/tests/test_gridspec.py
+++ b/tests/test_gridspec.py
@@ -118,8 +118,10 @@ def test_gridspec_ok(gs_in, gs_out):
         ({"grid": "N32", "shape": 6599680}, {"grid": [10, 10]}, None),
         ({"grid": "N32", "area": [90, 0, -90, 359.999]}, {"grid": [10, 10]}, None),
         ({"grid": "N32", "area": [90, -0.1, -90, 360]}, {"grid": [10, 10]}, None),
-        ({"grid": "ORCA025_T"}, {"grid": "O96"}, ValueError),
+        ({"grid": "ORCA025_T"}, {"grid": "O96"}, None),
         ({"grid": "eORCA025_U"}, {"grid": "O96"}, None),
+        ({"grid": "bORCA025_T"}, {"grid": "O96"}, ValueError),
+        ({"grid": "ORCA025_TU"}, {"grid": "O96"}, ValueError),
     ],
 )
 def test_gridspec_bad(gs_in, gs_out, err):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -226,8 +226,10 @@ def test_local_gridspec_ok(gs_in, gs_out):
         ({"grid": "N32", "area": [90, 0, -90, 359.999]}, {"grid": [10, 10]}, None),
         ({"grid": "N32", "area": [90, -0.1, -90, 360]}, {"grid": [10, 10]}, None),
         ({"grid": "H4", "ordering": "any"}, {"grid": [10, 10]}, ValueError),
-        ({"grid": "ORCA025_T"}, {"grid": "O96"}, ValueError),
+        ({"grid": "ORCA025_T"}, {"grid": "O96"}, None),
         ({"grid": "eORCA025_U"}, {"grid": "O96"}, None),
+        ({"grid": "bORCA025_T"}, {"grid": "O96"}, ValueError),
+        ({"grid": "ORCA025_TU"}, {"grid": "O96"}, ValueError),
     ],
 )
 def test_local_gridspec_bad(gs_in, gs_out, err):


### PR DESCRIPTION
This PR improves the ORCA gridspec checks allowing for all the following cases:

    ORCA025_[FTUV]
    ORCA12_[FTUV]
    ORCA1_[FTUV]
    ORCA2_[FTUV]
    eORCA025_[FTUV]
    eORCA12_[FTUV]
    eORCA1_[FTUV]

