### PR TITLE
feat: Regridding across array backends

### DIFF
--- a/src/earthkit/regrid/backends/matrix.py
+++ b/src/earthkit/regrid/backends/matrix.py
@@ -10,10 +10,10 @@
 from abc import abstractmethod
 from functools import cached_property
 
-from earthkit.utils.array import backend_from_array, ArrayBackend
+from earthkit.utils.array import ArrayBackend
+from earthkit.utils.array import backend_from_array
 
 from . import Backend
-
 
 
 def npz_to_backend(z, backend: ArrayBackend):
@@ -33,8 +33,10 @@ def npz_to_backend(z, backend: ArrayBackend):
             z,
             shape=z.shape,
         )
-    
-    raise NotImplementedError(f"Unsupported backend: {backend.name}. Supported backends are: numpy, torch, cupy.")
+
+    raise NotImplementedError(
+        f"Unsupported backend: {backend.name}. Supported backends are: numpy, torch, cupy."
+    )
 
 
 class MatrixBackend(Backend):
@@ -51,9 +53,9 @@ class MatrixBackend(Backend):
 
         # This should check for 1D (GG) and 2D (LL) matrices
         values = values.reshape(-1, 1)
-        z =  npz_to_backend(z, array_backend)
+        z = npz_to_backend(z, array_backend)
 
-        if array_backend.name == 'torch': # TODO: Use from utils
+        if array_backend.name == "torch":  # TODO: Use from utils
             z = z.to(values)
         values = z @ values
 

--- a/src/earthkit/regrid/data.py
+++ b/src/earthkit/regrid/data.py
@@ -12,6 +12,7 @@ from abc import ABCMeta
 from abc import abstractmethod
 
 import deprecation
+from earthkit.utils.array import backend_from_array
 
 LOG = logging.getLogger(__name__)
 
@@ -54,12 +55,14 @@ class DataHandler(metaclass=ABCMeta):
         return backend.interpolate(values, in_grid, out_grid, **kwargs)
 
 
-class NumpyDataHandler(DataHandler):
+class ArrayDataHandler(DataHandler):
     @staticmethod
     def match(values):
-        import numpy as np
-
-        return isinstance(values, np.ndarray)
+        try:
+            backend_from_array(values)
+            return True
+        except Exception:
+            return False
 
     def regrid(self, values, **kwargs):
         in_grid = kwargs.pop("in_grid")
@@ -174,7 +177,7 @@ class FieldListDataHandler(DataHandler):
         return r
 
 
-DATA_HANDLERS = [NumpyDataHandler(), FieldListDataHandler()]
+DATA_HANDLERS = [ArrayDataHandler(), FieldListDataHandler()]
 
 
 def get_data_handler(values):

--- a/src/earthkit/regrid/data.py
+++ b/src/earthkit/regrid/data.py
@@ -135,7 +135,7 @@ class FieldListDataHandler(DataHandler):
 
                 r += ds.from_fields([f])
                 continue
-            vv = f.to_numpy(flatten=True)
+            vv = f.to_array(flatten=True)
 
             in_grid_f = self.input_gridspec(in_grid, f, i)
 
@@ -146,7 +146,7 @@ class FieldListDataHandler(DataHandler):
                 **kwargs,
             )
             md_res = f.metadata().override(gridspec=out_grid_f)
-            r += ds.from_numpy(v_res, md_res)
+            r += ds.from_array(v_res, md_res)
 
         return r
 

--- a/src/earthkit/regrid/utils/hash.py
+++ b/src/earthkit/regrid/utils/hash.py
@@ -15,6 +15,11 @@ def make_sha(data):
     m = hashlib.sha256()
     if isinstance(data, str):
         m.update(data.encode("utf-8"))
-    else:
+    elif isinstance(data, dict):
         m.update(json.dumps(data, sort_keys=True).encode("utf-8"))
+    elif isinstance(data, (tuple, list)):
+        for item in data:
+            m.update(make_sha(item).encode("utf-8"))
+    else:
+        m.update(str(hash(data)).encode("utf-8"))
     return m.hexdigest()

--- a/src/earthkit/regrid/utils/memcache.py
+++ b/src/earthkit/regrid/utils/memcache.py
@@ -220,7 +220,7 @@ class MemoryCache:
         self.lock = threading.Lock()
         self.update()
 
-    def get(self, *args, create=None, find_entry=None, create_from_entry=None):
+    def get(self, *args, create=None, find_entry=None):
         if not self.policy.has_cache():
             return create(*args)
 
@@ -237,7 +237,7 @@ class MemoryCache:
                 return item.data
 
             if self.policy.has_limit():
-                data = self._create_with_pre_check(find_entry, create_from_entry, *args)
+                data = self._create_with_pre_check(find_entry, create, *args)
             else:
                 data = self._create(create, *args)
 
@@ -255,11 +255,11 @@ class MemoryCache:
             raise ValueError("create must be provided")
         return create(*args)
 
-    def _create_with_pre_check(self, find_entry, create_from_entry, *args):
+    def _create_with_pre_check(self, find_entry, create, *args):
         if find_entry is None:
             raise ValueError("find_entry must be provided")
-        if create_from_entry is None:
-            raise ValueError("create_from_entry must be provided")
+        if create is None:
+            raise ValueError("create must be provided")
 
         entry = find_entry(*args)
         if entry is not None:
@@ -279,7 +279,7 @@ class MemoryCache:
                     )
                 )
 
-        return create_from_entry(entry)
+        return create(*args)
 
     def update(self):
         """Called when settings change"""

--- a/src/earthkit/regrid/utils/testing.py
+++ b/src/earthkit/regrid/utils/testing.py
@@ -18,6 +18,10 @@ if not os.path.exists(os.path.join(_ROOT_DIR, "tests", "data")):
     _ROOT_DIR = "./"
 
 
+from earthkit.utils.testing import get_array_backend
+
+ARRAY_BACKENDS = get_array_backend(["numpy", "torch"], raise_on_missing=False) # TODO: Add cupy when supported
+
 def earthkit_file(*args):
     return os.path.join(_ROOT_DIR, *args)
 
@@ -68,3 +72,4 @@ def modules_installed(*modules):
 
 NO_EKD = not modules_installed("earthkit.data")
 NO_MIR = not modules_installed("mir")
+

--- a/src/earthkit/regrid/utils/testing.py
+++ b/src/earthkit/regrid/utils/testing.py
@@ -9,6 +9,8 @@
 import os
 from importlib import import_module
 
+from earthkit.utils.testing import get_array_backend
+
 PATH = os.path.dirname(__file__)
 
 URL_ROOT = "https://get.ecmwf.int/repository/test-data/earthkit-regrid/test-data"
@@ -18,9 +20,10 @@ if not os.path.exists(os.path.join(_ROOT_DIR, "tests", "data")):
     _ROOT_DIR = "./"
 
 
-from earthkit.utils.testing import get_array_backend
+ARRAY_BACKENDS = get_array_backend(
+    ["numpy", "torch"], raise_on_missing=False
+)  # TODO: Add cupy when supported
 
-ARRAY_BACKENDS = get_array_backend(["numpy", "torch"], raise_on_missing=False) # TODO: Add cupy when supported
 
 def earthkit_file(*args):
     return os.path.join(_ROOT_DIR, *args)
@@ -72,4 +75,3 @@ def modules_installed(*modules):
 
 NO_EKD = not modules_installed("earthkit.data")
 NO_MIR = not modules_installed("mir")
-

--- a/tests/regrid/test_backend_local_matrix.py
+++ b/tests/regrid/test_backend_local_matrix.py
@@ -12,8 +12,8 @@ import numpy as np
 import pytest
 
 from earthkit.regrid import regrid
-from earthkit.regrid.utils.testing import earthkit_test_data_path
 from earthkit.regrid.utils.testing import ARRAY_BACKENDS
+from earthkit.regrid.utils.testing import earthkit_test_data_path
 
 DB_PATH = earthkit_test_data_path("local", "db")
 DATA_PATH = earthkit_test_data_path("local")
@@ -143,7 +143,9 @@ def test_regrid_local_matrix_healpix_ring_to_ll(interpolation, array_backend):
 @pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
 def test_regrid_local_matrix_nested_to_ll(interpolation, array_backend):
     v_in = array_backend.asarray(np.load(file_in_testdir("in_H4_nested.npz"))["arr_0"])
-    v_ref = array_backend.asarray(np.load(file_in_testdir(f"out_H4_nested_10x10_{interpolation}.npz"))["arr_0"])
+    v_ref = array_backend.asarray(
+        np.load(file_in_testdir(f"out_H4_nested_10x10_{interpolation}.npz"))["arr_0"]
+    )
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in,

--- a/tests/regrid/test_backend_local_matrix.py
+++ b/tests/regrid/test_backend_local_matrix.py
@@ -13,6 +13,7 @@ import pytest
 
 from earthkit.regrid import regrid
 from earthkit.regrid.utils.testing import earthkit_test_data_path
+from earthkit.regrid.utils.testing import ARRAY_BACKENDS
 
 DB_PATH = earthkit_test_data_path("local", "db")
 DATA_PATH = earthkit_test_data_path("local")
@@ -73,9 +74,10 @@ def test_regrid_local_matrix_index():
 
 
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_local_matrix_ll_to_ll(interpolation):
-    v_in = np.load(file_in_testdir("in_5x5.npz"))["arr_0"]
-    v_ref = np.load(file_in_testdir(f"out_5x5_10x10_{interpolation}.npz"))["arr_0"]
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_local_matrix_ll_to_ll(interpolation, array_backend):
+    v_in = array_backend.asarray(np.load(file_in_testdir("in_5x5.npz"))["arr_0"])
+    v_ref = array_backend.asarray(np.load(file_in_testdir(f"out_5x5_10x10_{interpolation}.npz"))["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in, in_grid={"grid": [5, 5]}, out_grid=out_grid, interpolation=interpolation
@@ -83,13 +85,14 @@ def test_regrid_local_matrix_ll_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_local_matrix_ogg_to_ll(interpolation):
-    v_in = np.load(file_in_testdir("in_O32.npz"))["arr_0"]
-    v_ref = np.load(file_in_testdir(f"out_O32_10x10_{interpolation}.npz"))["arr_0"]
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_local_matrix_ogg_to_ll(interpolation, array_backend):
+    v_in = array_backend.asarray(np.load(file_in_testdir("in_O32.npz"))["arr_0"])
+    v_ref = array_backend.asarray(np.load(file_in_testdir(f"out_O32_10x10_{interpolation}.npz"))["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in, in_grid={"grid": "O32"}, out_grid=out_grid, interpolation=interpolation
@@ -97,13 +100,14 @@ def test_regrid_local_matrix_ogg_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_local_matrix_ngg_to_ll(interpolation):
-    v_in = np.load(file_in_testdir("in_N32.npz"))["arr_0"]
-    v_ref = np.load(file_in_testdir(f"out_N32_10x10_{interpolation}.npz"))["arr_0"]
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_local_matrix_ngg_to_ll(interpolation, array_backend):
+    v_in = array_backend.asarray(np.load(file_in_testdir("in_N32.npz"))["arr_0"])
+    v_ref = array_backend.asarray(np.load(file_in_testdir(f"out_N32_10x10_{interpolation}.npz"))["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in,
@@ -114,13 +118,14 @@ def test_regrid_local_matrix_ngg_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_local_matrix_healpix_ring_to_ll(interpolation):
-    v_in = np.load(file_in_testdir("in_H4_ring.npz"))["arr_0"]
-    v_ref = np.load(file_in_testdir(f"out_H4_ring_10x10_{interpolation}.npz"))["arr_0"]
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_local_matrix_healpix_ring_to_ll(interpolation, array_backend):
+    v_in = array_backend.asarray(np.load(file_in_testdir("in_H4_ring.npz"))["arr_0"])
+    v_ref = array_backend.asarray(np.load(file_in_testdir(f"out_H4_ring_10x10_{interpolation}.npz"))["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in,
@@ -131,13 +136,14 @@ def test_regrid_local_matrix_healpix_ring_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_local_matrix_nested_to_ll(interpolation):
-    v_in = np.load(file_in_testdir("in_H4_nested.npz"))["arr_0"]
-    v_ref = np.load(file_in_testdir(f"out_H4_nested_10x10_{interpolation}.npz"))["arr_0"]
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_local_matrix_nested_to_ll(interpolation, array_backend):
+    v_in = array_backend.asarray(np.load(file_in_testdir("in_H4_nested.npz"))["arr_0"])
+    v_ref = array_backend.asarray(np.load(file_in_testdir(f"out_H4_nested_10x10_{interpolation}.npz"))["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in,
@@ -148,7 +154,7 @@ def test_regrid_local_matrix_nested_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 # TODO: implement this test

--- a/tests/regrid/test_backend_matrix.py
+++ b/tests/regrid/test_backend_matrix.py
@@ -11,12 +11,14 @@ import pytest
 
 from earthkit.regrid import regrid
 from earthkit.regrid.utils.testing import get_test_data
+from earthkit.regrid.utils.testing import ARRAY_BACKENDS
 
 INTERPOLATIONS = ["linear", "nearest-neighbour"]
 
 
 @pytest.mark.download
 @pytest.mark.tmp_cache
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
 @pytest.mark.parametrize(
     "_kwarg,interpolation",
     [
@@ -28,24 +30,24 @@ INTERPOLATIONS = ["linear", "nearest-neighbour"]
         # ({"interpolation": "grid-box-average"}, "grid-box-average"),
     ],
 )
-def test_regrid_matrix_interpolation_kwarg(_kwarg, interpolation):
+def test_regrid_matrix_interpolation_kwarg(_kwarg, interpolation, array_backend):
     f_in, f_out = get_test_data(["in_O32.npz", f"out_O32_10x10_{interpolation}.npz"])
 
-    v_in = np.load(f_in)["arr_0"]
-    v_ref = np.load(f_out)["arr_0"]
+    v_in = array_backend.asarray(np.load(f_in)["arr_0"])
+    v_ref = array_backend.asarray(np.load(f_out)["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = regrid(v_in, {"grid": "O32"}, out_grid=out_grid, backend="system-matrix", **_kwarg)
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
-def _ll_to_ll(interpolation):
+def _ll_to_ll(interpolation, array_backend):
     f_in, f_out = get_test_data(["in_5x5.npz", f"out_5x5_10x10_{interpolation}.npz"])
-
-    v_in = np.load(f_in)["arr_0"]
-    v_ref = np.load(f_out)["arr_0"]
+    
+    v_in = array_backend.asarray(np.load(f_in)["arr_0"])
+    v_ref = array_backend.asarray(np.load(f_out)["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, res_grid = regrid(
         v_in, {"grid": [5, 5]}, out_grid=out_grid, interpolation=interpolation, backend="system-matrix"
@@ -53,7 +55,7 @@ def _ll_to_ll(interpolation):
 
     assert v_res.shape == (19, 36), 1
     assert res_grid == out_grid, 1
-    assert np.allclose(v_res.flatten(), v_ref), 1
+    assert array_backend.allclose(v_res.flatten(), v_ref), 1
 
     # repeated use
     v_res, grid_res = regrid(
@@ -62,30 +64,33 @@ def _ll_to_ll(interpolation):
 
     assert v_res.shape == (19, 36), 2
     assert grid_res == out_grid, 2
-    assert np.allclose(v_res.flatten(), v_ref), 2
+    assert array_backend.allclose(v_res.flatten(), v_ref), 2
 
 
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_matrix_ll_to_ll(interpolation):
-    _ll_to_ll(interpolation)
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_matrix_ll_to_ll(interpolation, array_backend):
+    _ll_to_ll(interpolation, array_backend)
 
 
 @pytest.mark.download
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_matrix_ll_to_ll_user_cache(interpolation):
-    _ll_to_ll(interpolation)
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_matrix_ll_to_ll_user_cache(interpolation, array_backend):
+    _ll_to_ll(interpolation, array_backend)
 
 
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_matrix_ogg_to_ll(interpolation):
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_matrix_ogg_to_ll(interpolation, array_backend):
     f_in, f_out = get_test_data(["in_O32.npz", f"out_O32_10x10_{interpolation}.npz"])
 
-    v_in = np.load(f_in)["arr_0"]
-    v_ref = np.load(f_out)["arr_0"]
+    v_in = array_backend.asarray(np.load(f_in)["arr_0"])
+    v_ref = array_backend.asarray(np.load(f_out)["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = regrid(
         v_in, {"grid": "O32"}, out_grid=out_grid, interpolation=interpolation, backend="system-matrix"
@@ -93,17 +98,18 @@ def test_regrid_matrix_ogg_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_matrix_ngg_to_ll(interpolation):
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_matrix_ngg_to_ll(interpolation, array_backend):
     f_in, f_out = get_test_data(["in_N32.npz", f"out_N32_10x10_{interpolation}.npz"])
 
-    v_in = np.load(f_in)["arr_0"]
-    v_ref = np.load(f_out)["arr_0"]
+    v_in = array_backend.asarray(np.load(f_in)["arr_0"])
+    v_ref = array_backend.asarray(np.load(f_out)["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = regrid(
         v_in, {"grid": "N32"}, out_grid=out_grid, interpolation=interpolation, backend="system-matrix"
@@ -111,17 +117,18 @@ def test_regrid_matrix_ngg_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_matrix_healpix_ring_to_ll(interpolation):
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_matrix_healpix_ring_to_ll(interpolation, array_backend):
     f_in, f_out = get_test_data(["in_H4_ring.npz", f"out_H4_ring_10x10_{interpolation}.npz"])
 
-    v_in = np.load(f_in)["arr_0"]
-    v_ref = np.load(f_out)["arr_0"]
+    v_in = array_backend.asarray(np.load(f_in)["arr_0"])
+    v_ref = array_backend.asarray(np.load(f_out)["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = regrid(
         v_in,
@@ -133,17 +140,18 @@ def test_regrid_matrix_healpix_ring_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.parametrize("interpolation", INTERPOLATIONS)
-def test_regrid_matrix_healpix_nested_to_ll(interpolation):
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
+def test_regrid_matrix_healpix_nested_to_ll(interpolation, array_backend):
     f_in, f_out = get_test_data(["in_H4_nested.npz", f"out_H4_nested_10x10_{interpolation}.npz"])
 
-    v_in = np.load(f_in)["arr_0"]
-    v_ref = np.load(f_out)["arr_0"]
+    v_in = array_backend.asarray(np.load(f_in)["arr_0"])
+    v_ref = array_backend.asarray(np.load(f_out)["arr_0"])
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = regrid(
         v_in,
@@ -155,7 +163,7 @@ def test_regrid_matrix_healpix_nested_to_ll(interpolation):
 
     assert v_res.shape == (19, 36)
     assert grid_res == out_grid
-    assert np.allclose(v_res.flatten(), v_ref)
+    assert array_backend.allclose(v_res.flatten(), v_ref)
 
 
 @pytest.mark.tmp_cache

--- a/tests/regrid/test_backend_matrix.py
+++ b/tests/regrid/test_backend_matrix.py
@@ -10,8 +10,8 @@ import numpy as np
 import pytest
 
 from earthkit.regrid import regrid
-from earthkit.regrid.utils.testing import get_test_data
 from earthkit.regrid.utils.testing import ARRAY_BACKENDS
+from earthkit.regrid.utils.testing import get_test_data
 
 INTERPOLATIONS = ["linear", "nearest-neighbour"]
 
@@ -45,7 +45,7 @@ def test_regrid_matrix_interpolation_kwarg(_kwarg, interpolation, array_backend)
 
 def _ll_to_ll(interpolation, array_backend):
     f_in, f_out = get_test_data(["in_5x5.npz", f"out_5x5_10x10_{interpolation}.npz"])
-    
+
     v_in = array_backend.asarray(np.load(f_in)["arr_0"])
     v_ref = array_backend.asarray(np.load(f_out)["arr_0"])
     out_grid = {"grid": [10, 10]}

--- a/tests/regrid/test_fieldlist.py
+++ b/tests/regrid/test_fieldlist.py
@@ -11,10 +11,10 @@ import numpy as np
 import pytest
 
 from earthkit.regrid import regrid
+from earthkit.regrid.utils.testing import ARRAY_BACKENDS
 from earthkit.regrid.utils.testing import NO_EKD  # noqa: E402
 from earthkit.regrid.utils.testing import get_test_data  # noqa: E402
 from earthkit.regrid.utils.testing import get_test_data_path  # noqa: E402
-from earthkit.regrid.utils.testing import ARRAY_BACKENDS
 
 if not NO_EKD:
     from earthkit.data import from_source  # noqa
@@ -35,7 +35,7 @@ if not NO_EKD:
     ],
 )
 def test_regrid_matrix_fieldlist_reg_ll(_kwarg, interpolation, array_backend):
-    ds = from_source("url", get_test_data_path("5x5.grib")).to_fieldlist(array_backend = array_backend)
+    ds = from_source("url", get_test_data_path("5x5.grib")).to_fieldlist(array_backend=array_backend)
 
     f_ref = get_test_data(f"out_5x5_10x10_{interpolation}.npz")
     v_ref = array_backend.asarray(np.load(f_ref)["arr_0"])
@@ -62,7 +62,7 @@ def test_regrid_matrix_fieldlist_reg_ll(_kwarg, interpolation, array_backend):
     ],
 )
 def test_regrid_matrix_fieldlist_gg(_kwarg, interpolation, array_backend):
-    ds = from_source("url", get_test_data_path("O32.grib")).to_fieldlist(array_backend = array_backend)
+    ds = from_source("url", get_test_data_path("O32.grib")).to_fieldlist(array_backend=array_backend)
 
     f_ref = get_test_data(f"out_O32_10x10_{interpolation}.npz")
     v_ref = array_backend.asarray(np.load(f_ref)["arr_0"])
@@ -87,7 +87,7 @@ def test_regrid_matrix_fieldlist_gg(_kwarg, interpolation, array_backend):
     ],
 )
 def test_regrid_grib_fieldlist(_kwarg, array_backend):
-    ds = from_source("url", get_test_data_path("O32.grib")).to_fieldlist(array_backend = array_backend)
+    ds = from_source("url", get_test_data_path("O32.grib")).to_fieldlist(array_backend=array_backend)
 
     r = regrid(ds, out_grid={"grid": [10, 10]}, **_kwarg)
     assert len(r) == 1

--- a/tests/regrid/test_fieldlist.py
+++ b/tests/regrid/test_fieldlist.py
@@ -14,6 +14,7 @@ from earthkit.regrid import regrid
 from earthkit.regrid.utils.testing import NO_EKD  # noqa: E402
 from earthkit.regrid.utils.testing import get_test_data  # noqa: E402
 from earthkit.regrid.utils.testing import get_test_data_path  # noqa: E402
+from earthkit.regrid.utils.testing import ARRAY_BACKENDS
 
 if not NO_EKD:
     from earthkit.data import from_source  # noqa
@@ -22,6 +23,7 @@ if not NO_EKD:
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.skipif(NO_EKD, reason="No access to earthkit-data")
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
 @pytest.mark.parametrize(
     "_kwarg,interpolation",
     [
@@ -32,22 +34,23 @@ if not NO_EKD:
         ({"interpolation": "nearest-neighbor"}, "nearest-neighbour"),
     ],
 )
-def test_regrid_matrix_fieldlist_reg_ll(_kwarg, interpolation):
-    ds = from_source("url", get_test_data_path("5x5.grib"))
+def test_regrid_matrix_fieldlist_reg_ll(_kwarg, interpolation, array_backend):
+    ds = from_source("url", get_test_data_path("5x5.grib")).to_fieldlist(array_backend = array_backend)
 
     f_ref = get_test_data(f"out_5x5_10x10_{interpolation}.npz")
-    v_ref = np.load(f_ref)["arr_0"]
+    v_ref = array_backend.asarray(np.load(f_ref)["arr_0"])
 
     r = regrid(ds, out_grid={"grid": [10, 10]}, backend="system-matrix", **_kwarg)
 
     assert len(r) == 1
     assert r[0].shape == (19, 36)
-    assert np.allclose(r[0].values, v_ref)
+    assert array_backend.allclose(r[0].values, v_ref)
 
 
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.skipif(NO_EKD, reason="No access to earthkit-data")
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
 @pytest.mark.parametrize(
     "_kwarg,interpolation",
     [
@@ -58,20 +61,21 @@ def test_regrid_matrix_fieldlist_reg_ll(_kwarg, interpolation):
         ({"interpolation": "nearest-neighbor"}, "nearest-neighbour"),
     ],
 )
-def test_regrid_matrix_fieldlist_gg(_kwarg, interpolation):
-    ds = from_source("url", get_test_data_path("O32.grib"))
+def test_regrid_matrix_fieldlist_gg(_kwarg, interpolation, array_backend):
+    ds = from_source("url", get_test_data_path("O32.grib")).to_fieldlist(array_backend = array_backend)
 
     f_ref = get_test_data(f"out_O32_10x10_{interpolation}.npz")
-    v_ref = np.load(f_ref)["arr_0"]
+    v_ref = array_backend.asarray(np.load(f_ref)["arr_0"])
 
     r = regrid(ds, out_grid={"grid": [10, 10]}, backend="system-matrix", **_kwarg)
 
     assert len(r) == 1
     assert r[0].shape == (19, 36)
-    assert np.allclose(r[0].values, v_ref)
+    assert array_backend.allclose(r[0].values, v_ref)
 
 
 @pytest.mark.skipif(NO_EKD, reason="No access to earthkit-data")
+@pytest.mark.parametrize("array_backend", ARRAY_BACKENDS)
 @pytest.mark.parametrize(
     "_kwarg",
     [
@@ -82,8 +86,8 @@ def test_regrid_matrix_fieldlist_gg(_kwarg, interpolation):
         ({"interpolation": "nearest-neighbor"}),
     ],
 )
-def test_regrid_grib_fieldlist(_kwarg):
-    ds = from_source("url", get_test_data_path("O32.grib"))
+def test_regrid_grib_fieldlist(_kwarg, array_backend):
+    ds = from_source("url", get_test_data_path("O32.grib")).to_fieldlist(array_backend = array_backend)
 
     r = regrid(ds, out_grid={"grid": [10, 10]}, **_kwarg)
     assert len(r) == 1


### PR DESCRIPTION
### Description
Allow for regridding across array backends.

Converts the sparse matrix into the backend defined by the values array, Caches that type.
> [!NOTE]
> Does cache on device, so memory needs to be addressed.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 