### PR TITLE
Use order key instead of ordering in healpix gridspec

### DIFF
--- a/docs/guide/interpolate/gridspec.rst
+++ b/docs/guide/interpolate/gridspec.rst
@@ -64,13 +64,13 @@ The ``grid`` format is::
 
     HXXX
 
-The ``ordering`` must be set to ``"nested"``. For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
+The ``order`` must be set to ``"nested"``. For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
 
 Example:
 
 .. code-block::
 
-    {"grid": "H512", "ordering": "nested"}
+    {"grid": "H512", "order": "nested"}
 
 
 HEALPix ring grid
@@ -80,13 +80,13 @@ The ``grid`` format is::
 
     HXXX
 
-The ``ordering`` can be omitted or set to ``"ring"``.  For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
+The ``order`` can be omitted or set to ``"ring"``.  For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
 
 Example:
 
 .. code-block::
 
-    {"grid": "H512", "ordering": "ring"}
+    {"grid": "H512", "order": "ring"}
     {"grid": "H512"}
 
 

--- a/docs/guide/mir/gridspec.rst
+++ b/docs/guide/mir/gridspec.rst
@@ -64,13 +64,13 @@ The ``grid`` format is::
 
     HXXX
 
-The ``ordering`` must be set to ``"nested"``. For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
+The ``order`` must be set to ``"nested"``. For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
 
 Example:
 
 .. code-block::
 
-    {"grid": "H512", "ordering": "nested"}
+    {"grid": "H512", "order": "nested"}
 
 
 HEALPix ring grid
@@ -80,13 +80,13 @@ The ``grid`` format is::
 
     HXXX
 
-The ``ordering`` can be omitted or set to ``"ring"``.  For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
+The ``order`` can be omitted or set to ``"ring"``.  For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
 
 Example:
 
 .. code-block::
 
-    {"grid": "H512", "ordering": "ring"}
+    {"grid": "H512", "order": "ring"}
     {"grid": "H512"}
 
 

--- a/docs/guide/precomputed/gridspec.rst
+++ b/docs/guide/precomputed/gridspec.rst
@@ -64,13 +64,13 @@ The ``grid`` format is::
 
     HXXX
 
-The ``ordering`` must be set to ``"nested"``. For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
+The ``order`` must be set to ``"nested"``. For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
 
 Example:
 
 .. code-block::
 
-    {"grid": "H512", "ordering": "nested"}
+    {"grid": "H512", "order": "nested"}
 
 
 HEALPix ring grid
@@ -80,13 +80,13 @@ The ``grid`` format is::
 
     HXXX
 
-The ``ordering`` can be omitted or set to ``"ring"``.  For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
+The ``order`` can be omitted or set to ``"ring"``.  For details about this grid, see `here  <https://en.wikipedia.org/wiki/HEALPix>`_.
 
 Example:
 
 .. code-block::
 
-    {"grid": "H512", "ordering": "ring"}
+    {"grid": "H512", "order": "ring"}
     {"grid": "H512"}
 
 

--- a/docs/guide/precomputed/local/regrid.rst
+++ b/docs/guide/precomputed/local/regrid.rst
@@ -6,7 +6,7 @@ regrid
 .. py:function:: regrid(values, in_grid=None, out_grid=None, interpolation='linear', output="values_gridspec", backend="precomputed-local", inventory_path=None)
     :noindex:
 
-    Regrid the ``values`` with using precomputed weights stored at a local path.
+    Regrid the ``values`` using precomputed weights stored at a local path.
 
     :param values: the following input data types are supported:
 

--- a/docs/guide/precomputed/system/regrid.rst
+++ b/docs/guide/precomputed/system/regrid.rst
@@ -6,7 +6,7 @@ regrid
 .. py:function:: regrid(values, in_grid=None, out_grid=None, interpolation='linear', output="values_gridspec", backend="precomputed", **kwargs)
     :noindex:
 
-    Regrid the ``values`` with using precomputed weights stored in a remote inventory managed by ECMWF.
+    Regrid the ``values`` using precomputed weights stored in a remote inventory managed by ECMWF.
 
     :param values: the following input data types are supported:
 

--- a/src/earthkit/regrid/gridspec.py
+++ b/src/earthkit/regrid/gridspec.py
@@ -363,10 +363,14 @@ class HealpixGridSpec(GridSpec):
     def __init__(self, gs):
         super().__init__(gs)
 
+        # the offical key is "order", we still support "ordering" for compatibility
+        if "ordering" in gs:
+            self["order"] = self.pop("ordering")
+
         self._global_ew = True
         self._global_ns = True
         self.setdefault("area", self.DEFAULT_AREA)
-        self._ordering = None
+        self._order = None
         self._N = None
 
     @property
@@ -388,10 +392,10 @@ class HealpixGridSpec(GridSpec):
         if not super().__eq__(o):
             return False
 
-        return self.ordering == o.ordering
+        return self.order == o.order
 
     def _inspect_grid(self):
-        if self._N is None or self._ordering is None:
+        if self._N is None or self._order is None:
             grid = self["grid"]
             if not self.type_match(grid):
                 raise ValueError(f"Invalid healpix {grid=}")
@@ -401,14 +405,14 @@ class HealpixGridSpec(GridSpec):
             except Exception:
                 raise ValueError(f"Invalid healpix number in {grid=}")
 
-            ordering = self.get("ordering", "ring")
-            if ordering not in ["ring", "nested"]:
-                raise ValueError(f"Invalid {ordering=}, must be 'ring' or 'nested'")
+            order = self.get("order", "ring")
+            if order not in ["ring", "nested"]:
+                raise ValueError(f"Invalid {order=}, must be 'ring' or 'nested'")
 
             if N < 1 or N > 1000000:
                 raise ValueError(f"Invalid healpix number in {grid=}")
             self._N = N
-            self._ordering = ordering
+            self._order = order
 
     @property
     def N(self):
@@ -417,10 +421,10 @@ class HealpixGridSpec(GridSpec):
         return self._N
 
     @property
-    def ordering(self):
-        if self._ordering is None:
+    def order(self):
+        if self._order is None:
             self._inspect_grid()
-        return self._ordering
+        return self._order
 
     @staticmethod
     def type_match(grid):

--- a/src/earthkit/regrid/sphinxext/generate_inventory_rst.py
+++ b/src/earthkit/regrid/sphinxext/generate_inventory_rst.py
@@ -12,7 +12,7 @@ import json
 from collections import defaultdict
 from collections import namedtuple
 
-from earthkit.regrid.db import SYS_DB as DB
+from earthkit.regrid.backends.db import SYS_DB as DB
 from earthkit.regrid.gridspec import GridSpec
 
 Specs = namedtuple("Specs", ["source", "target"])
@@ -27,7 +27,7 @@ def to_str(gs):
 
     grid = gs["grid"]
     if isinstance(grid, str) and grid.startswith("H"):
-        return {"grid": gs["grid"], "ordering": gs["ordering"]}
+        return {"grid": gs["grid"], "order": gs["order"]}
     else:
         return {"grid": gs["grid"]}
 
@@ -155,10 +155,10 @@ def execute(*args):
         gs["octahedral"] = False
     elif grid_type == "healpix_ring":
         gs["type"] = "healpix"
-        gs["ordering"] = "ring"
+        gs["order"] = "ring"
     elif grid_type == "healpix_nested":
         gs["type"] = "healpix"
-        gs["ordering"] = "nested"
+        gs["order"] = "nested"
     else:
         gs["type"] = grid_type
 

--- a/src/earthkit/regrid/utils/builder.py
+++ b/src/earthkit/regrid/utils/builder.py
@@ -51,7 +51,7 @@ def reduced_gg(entry):
 
 
 def healpix(entry):
-    d = {"grid": entry["grid"], "ordering": entry["ordering"]}
+    d = {"grid": entry["grid"], "order": entry["order"]}
     return d
 
 

--- a/tests/interpolate/test_matrix_interpolate.py
+++ b/tests/interpolate/test_matrix_interpolate.py
@@ -100,12 +100,13 @@ def test_ngg_to_ll(method):
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.parametrize("method", METHODS)
-def test_healpix_ring_to_ll(method):
+@pytest.mark.parametrize("order_key", ["order", "ordering"])
+def test_healpix_ring_to_ll(method, order_key):
     f_in, f_out = get_test_data(["in_H4_ring.npz", f"out_H4_ring_10x10_{method}.npz"])
 
     v_in = np.load(f_in)["arr_0"]
     v_ref = np.load(f_out)["arr_0"]
-    v_res = interpolate(v_in, {"grid": "H4", "ordering": "ring"}, {"grid": [10, 10]}, method=method)
+    v_res = interpolate(v_in, {"grid": "H4", order_key: "ring"}, {"grid": [10, 10]}, method=method)
 
     assert v_res.shape == (19, 36)
     assert np.allclose(v_res.flatten(), v_ref)
@@ -114,12 +115,13 @@ def test_healpix_ring_to_ll(method):
 @pytest.mark.download
 @pytest.mark.tmp_cache
 @pytest.mark.parametrize("method", METHODS)
-def test_healpix_nested_to_ll(method):
+@pytest.mark.parametrize("order_key", ["order", "ordering"])
+def test_healpix_nested_to_ll(method, order_key):
     f_in, f_out = get_test_data(["in_H4_nested.npz", f"out_H4_nested_10x10_{method}.npz"])
 
     v_in = np.load(f_in)["arr_0"]
     v_ref = np.load(f_out)["arr_0"]
-    v_res = interpolate(v_in, {"grid": "H4", "ordering": "nested"}, {"grid": [10, 10]}, method=method)
+    v_res = interpolate(v_in, {"grid": "H4", order_key: "nested"}, {"grid": [10, 10]}, method=method)
 
     assert v_res.shape == (19, 36)
     assert np.allclose(v_res.flatten(), v_ref)

--- a/tests/interpolate/test_matrix_local.py
+++ b/tests/interpolate/test_matrix_local.py
@@ -112,7 +112,7 @@ def test_local_healpix_ring_to_ll(method):
     v_ref = np.load(file_in_testdir(f"out_H4_ring_10x10_{method}.npz"))["arr_0"]
     v_res = run_interpolate(
         v_in,
-        in_grid={"grid": "H4", "ordering": "ring"},
+        in_grid={"grid": "H4", "order": "ring"},
         out_grid={"grid": [10, 10]},
         method=method,
     )
@@ -127,7 +127,7 @@ def test_local_healpix_nested_to_ll(method):
     v_ref = np.load(file_in_testdir(f"out_H4_nested_10x10_{method}.npz"))["arr_0"]
     v_res = run_interpolate(
         v_in,
-        in_grid={"grid": "H4", "ordering": "nested"},
+        in_grid={"grid": "H4", "order": "nested"},
         out_grid={"grid": [10, 10]},
         method=method,
     )
@@ -197,6 +197,7 @@ def test_local_healpix_nested_to_ll(method):
             {"grid": [10, 10]},
         ),
         ({"grid": "H4"}, {"grid": [10, 10]}),
+        ({"grid": "H4", "order": "ring"}, {"grid": [10, 10]}),
         ({"grid": "H4", "ordering": "ring"}, {"grid": [10, 10]}),
         ({"grid": "eORCA025_T"}, {"grid": "O96"}),
     ],
@@ -234,6 +235,7 @@ def test_local_gridspec_ok(gs_in, gs_out):
         ({"grid": "N32", "shape": 6599680}, {"grid": [10, 10]}, None),
         ({"grid": "N32", "area": [90, 0, -90, 359.999]}, {"grid": [10, 10]}, None),
         ({"grid": "N32", "area": [90, -0.1, -90, 360]}, {"grid": [10, 10]}, None),
+        ({"grid": "H4", "order": "any"}, {"grid": [10, 10]}, ValueError),
         ({"grid": "H4", "ordering": "any"}, {"grid": [10, 10]}, ValueError),
         ({"grid": "ORCA025_T"}, {"grid": "O96"}, None),
         ({"grid": "eORCA025_U"}, {"grid": "O96"}, None),

--- a/tests/inventory/test_gridspec.py
+++ b/tests/inventory/test_gridspec.py
@@ -81,6 +81,7 @@ from earthkit.regrid.backends.db import SYS_DB
             {"grid": [10, 10]},
         ),
         ({"grid": "H128"}, {"grid": [1, 1]}),
+        ({"grid": "H128", "order": "ring"}, {"grid": [1, 1]}),
         ({"grid": "H128", "ordering": "ring"}, {"grid": [1, 1]}),
         ({"grid": (5, 5)}, {"grid": (10, 10)}),
         ({"grid": "eORCA025_T"}, {"grid": "O96"}),

--- a/tests/regrid_backends/test_backend_local_matrix.py
+++ b/tests/regrid_backends/test_backend_local_matrix.py
@@ -125,7 +125,7 @@ def test_regrid_local_matrix_healpix_ring_to_ll(interpolation):
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in,
-        in_grid={"grid": "H4", "ordering": "ring"},
+        in_grid={"grid": "H4", "order": "ring"},
         out_grid=out_grid,
         interpolation=interpolation,
     )
@@ -142,7 +142,7 @@ def test_regrid_local_matrix_nested_to_ll(interpolation):
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = run_regrid(
         v_in,
-        in_grid={"grid": "H4", "ordering": "nested"},
+        in_grid={"grid": "H4", "order": "nested"},
         out_grid=out_grid,
         interpolation=interpolation,
     )

--- a/tests/regrid_backends/test_backend_matrix.py
+++ b/tests/regrid_backends/test_backend_matrix.py
@@ -144,7 +144,7 @@ def test_regrid_matrix_healpix_ring_to_ll(interpolation):
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = regrid(
         v_in,
-        {"grid": "H4", "ordering": "ring"},
+        {"grid": "H4", "order": "ring"},
         out_grid=out_grid,
         interpolation=interpolation,
         backend=SYSTEM_MATRIX_BACKEND_NAME,
@@ -166,7 +166,7 @@ def test_regrid_matrix_healpix_nested_to_ll(interpolation):
     out_grid = {"grid": [10, 10]}
     v_res, grid_res = regrid(
         v_in,
-        {"grid": "H4", "ordering": "nested"},
+        {"grid": "H4", "order": "nested"},
         out_grid=out_grid,
         interpolation=interpolation,
         backend=SYSTEM_MATRIX_BACKEND_NAME,

--- a/tests/regrid_mir/test_mir_grid.py
+++ b/tests/regrid_mir/test_mir_grid.py
@@ -60,10 +60,10 @@ INTERPOLATIONS = ["linear", "nearest-neighbour", "grid-box-average"]
             {"grid": [10, 10]},
         ),
         ({"grid": "H4"}, {"grid": [10, 10]}),
-        ({"grid": "H4", "ordering": "ring"}, {"grid": [10, 10]}),
+        ({"grid": "H4", "order": "ring"}, {"grid": [10, 10]}),
         # ({"grid": "eORCA025_T"}, {"grid": "O96"}),
         # ---
-        ({"grid": "H4", "ordering": "nested"}, {"grid": [10, 10]}),
+        ({"grid": "H4", "order": "nested"}, {"grid": [10, 10]}),
     ],
 )
 def test_regrid_with_mir_gridspec(gs_in, gs_out):

--- a/tests/regrid_mir/test_regrid_numpy.py
+++ b/tests/regrid_mir/test_regrid_numpy.py
@@ -114,9 +114,7 @@ def test_regrid_healpix_ring_to_ll(interpolation):
 
     v_in = np.load(f_in)["arr_0"]
     v_ref = np.load(f_out)["arr_0"]
-    v_res, _ = regrid(
-        v_in, {"grid": "H4", "ordering": "ring"}, {"grid": [10, 10]}, interpolation=interpolation
-    )
+    v_res, _ = regrid(v_in, {"grid": "H4", "order": "ring"}, {"grid": [10, 10]}, interpolation=interpolation)
 
     assert v_res.shape == (19, 36)
     np.testing.assert_allclose(v_res.flatten(), v_ref, verbose=False)
@@ -132,18 +130,14 @@ def test_regrid_healpix_nested_to_ll(interpolation):
     v_in = np.load(f_in)["arr_0"]
     v_ref = np.load(f_out)["arr_0"]
     v_res, _ = regrid(
-        v_in, {"grid": "H4", "ordering": "nested"}, {"grid": [10, 10]}, interpolation=interpolation
+        v_in, {"grid": "H4", "order": "nested"}, {"grid": [10, 10]}, interpolation=interpolation
     )
 
     assert v_res.shape == (19, 36)
     v_ref = v_ref.reshape(v_res.shape)
 
-    print(v_res[0, :20])
-    print(v_res[1, :20])
-    print(v_res[2, :20])
-    print()
-    print(v_ref[0, :20])
-    print(v_ref[1, :20])
-    print(v_ref[2, :20])
+    # print(v_res[0, :20] - v_ref[0, :20])
+    # print(v_res[1, :20] - v_ref[1, :20])
+    # print(v_res[2, :20] - v_ref[2, :20])
 
-    np.testing.assert_allclose(v_res.flatten(), v_ref, verbose=False)
+    np.testing.assert_allclose(v_res.flatten(), v_ref.flatten(), verbose=False)


### PR DESCRIPTION
Use the "order" key instead of "ordering" in the HEALPix gridspec. Using "ordering" is still possible for the "matrix" backends for backward compatibility. E.g. these calls still work:

```python
import earthkit.regrid as ekr

ekr.interpolate(v, in_grid={"grid": "H4", "ordering": "nested"}, out_grid={"grid": [10,10]})
ekr.regrid(v, in_grid={"grid": "H4", "ordering": "nested"}, 
                    out_grid={"grid": [10,10]}, backend="precomputed")
```

However, the expected code is as follows:

```python
import earthkit.regrid as ekr

ekr.interpolate(v, in_grid={"grid": "H4", "order": "nested"}, out_grid={"grid": [10,10]})
ekr.regrid(v, in_grid={"grid": "H4", "order": "nested"}, 
                    out_grid={"grid": [10,10]}, backend="precomputed")
```
