### PR TITLE
Remove mir dependency to make develop ci work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = [ "version" ]
 dependencies = [
   "deprecation",
   "filelock",
-  "mir-python>=1.27.2.dev20250723",
+  #"mir-python>=1.27.2.dev20250723",
   "multiurl",
   "pyyaml",
   "scipy",


### PR DESCRIPTION
Disabled the MIR dependency temporarily to make the CI for the develop branch work.