### PR TITLE
Add xarray interface to regrid

### DIFF
--- a/src/earthkit/regrid/backends/__init__.py
+++ b/src/earthkit/regrid/backends/__init__.py
@@ -96,12 +96,6 @@ class BackendMaker:
 
         return backend
 
-    def plugin_names(self):
-        """Return the list of plugin names."""
-        from earthkit.regrid.utils.plugins import load_plugins
-
-        return list(load_plugins("backend").keys())
-
     def _builtins(self):
         """Scan for built-in backend classes."""
         r = {}

--- a/src/earthkit/regrid/backends/mir.py
+++ b/src/earthkit/regrid/backends/mir.py
@@ -8,13 +8,28 @@
 #
 
 from . import Backend
+from warnings import warn
 
 
 class MirBackend(Backend):
     name = "mir"
 
+    def patch_grid(self, grid, kwargs):
+
+        # TODO: remove this once we have a better way to handle area in gridspec
+        if "area" in grid:
+            warn(
+                "The area key is a temporary workaround for area in gridspec",
+                 DeprecationWarning, stacklevel=2
+            )
+            area = grid.pop("area")
+            kwargs["area"] = area
+        return kwargs
+
     def regrid(self, values, in_grid, out_grid, interpolation, output=Backend.outputs[0], **kwargs):
         import mir
+
+        self.patch_grid(out_grid, kwargs)
 
         input = mir.ArrayInput(values, in_grid)
         out = mir.ArrayOutput()
@@ -40,6 +55,8 @@ class MirBackend(Backend):
         from io import BytesIO
 
         import mir
+
+        self.patch_grid(out_grid, kwargs)
 
         in_data = mir.GribMemoryInput(message)
         out = BytesIO()

--- a/src/earthkit/regrid/backends/mir.py
+++ b/src/earthkit/regrid/backends/mir.py
@@ -7,7 +7,6 @@
 # nor does it submit to any jurisdiction.
 #
 
-from warnings import warn
 
 from . import Backend
 
@@ -15,23 +14,8 @@ from . import Backend
 class MirBackend(Backend):
     name = "mir"
 
-    def patch_grid(self, grid, kwargs):
-
-        # TODO: remove this once we have a better way to handle area in gridspec
-        if "area" in grid:
-            warn(
-                "The area key is a temporary workaround for area in gridspec",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            area = grid.pop("area")
-            kwargs["area"] = area
-        return kwargs
-
     def regrid(self, values, in_grid, out_grid, interpolation, output=Backend.outputs[0], **kwargs):
         import mir
-
-        self.patch_grid(out_grid, kwargs)
 
         input = mir.ArrayInput(values, in_grid)
         out = mir.ArrayOutput()
@@ -57,8 +41,6 @@ class MirBackend(Backend):
         from io import BytesIO
 
         import mir
-
-        self.patch_grid(out_grid, kwargs)
 
         in_data = mir.GribMemoryInput(message)
         out = BytesIO()

--- a/src/earthkit/regrid/backends/mir.py
+++ b/src/earthkit/regrid/backends/mir.py
@@ -7,8 +7,9 @@
 # nor does it submit to any jurisdiction.
 #
 
-from . import Backend
 from warnings import warn
+
+from . import Backend
 
 
 class MirBackend(Backend):
@@ -20,7 +21,8 @@ class MirBackend(Backend):
         if "area" in grid:
             warn(
                 "The area key is a temporary workaround for area in gridspec",
-                 DeprecationWarning, stacklevel=2
+                DeprecationWarning,
+                stacklevel=2,
             )
             area = grid.pop("area")
             kwargs["area"] = area

--- a/src/earthkit/regrid/data/__init__.py
+++ b/src/earthkit/regrid/data/__init__.py
@@ -10,8 +10,16 @@
 
 from importlib import import_module
 
+_modules = [
+    "numpy",
+    "fieldlist",
+    "grib",
+    "xarray",
+]
+
+
 DATA_HANDLERS = []
-for name in ["numpy", "fieldlist", "grib", "xarray"]:
+for name in _modules:
     module = import_module(f".{name}", package=__name__)
     lst = getattr(module, "handler", [])
     if not isinstance(lst, list):
@@ -23,4 +31,5 @@ for name in ["numpy", "fieldlist", "grib", "xarray"]:
 def get_data_handler(values):
     for h in DATA_HANDLERS:
         if h.match(values):
-            return h
+            # TODO: rethink if we need to create a new handler instance each time
+            return h()

--- a/src/earthkit/regrid/data/__init__.py
+++ b/src/earthkit/regrid/data/__init__.py
@@ -1,0 +1,26 @@
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+from importlib import import_module
+
+DATA_HANDLERS = []
+for name in ["numpy", "fieldlist", "grib", "xarray"]:
+    module = import_module(f".{name}", package=__name__)
+    lst = getattr(module, "handler", [])
+    if not isinstance(lst, list):
+        lst = [lst]
+    assert isinstance(lst, list), f"Expected a list of handlers in {module.__name__}"
+    DATA_HANDLERS.extend(lst)
+
+
+def get_data_handler(values):
+    for h in DATA_HANDLERS:
+        if h.match(values):
+            return h

--- a/src/earthkit/regrid/data/fieldlist.py
+++ b/src/earthkit/regrid/data/fieldlist.py
@@ -134,37 +134,7 @@ class FieldDataHandler(DataHandler):
         from earthkit.data import FieldList
 
         ds = FieldList.from_fields([values])
-        return FIELDLIST_DATA_HANDLER.regrid(ds, **kwargs)[0]
+        return FieldListDataHandler().regrid(ds, **kwargs)[0]
 
 
-class GribMessageDataHandler(DataHandler):
-    @staticmethod
-    def match(values):
-        if isinstance(values, bytes):
-            return True
-        else:
-            from io import BytesIO
-
-            # TODO: add further checks to see if the object is a GRIB message
-            if isinstance(values, BytesIO):
-                return True
-        return False
-
-    def regrid(self, values, **kwargs):
-        backend = self.backend_from_kwargs(kwargs)
-        # backend = self.get_backend(kwargs.pop("backend"), matrix_source=kwargs.pop("matrix_source", None))
-        if hasattr(backend, "regrid_grib"):
-            if not isinstance(values, bytes):
-                from io import BytesIO
-
-                if isinstance(values, BytesIO):
-                    values = values.getvalue()
-
-            kwargs.pop("in_grid", None)
-            return backend.regrid_grib(values, **kwargs)
-        else:
-            raise ValueError(f"regrid() does not support GRIB message input for {backend=}!")
-
-
-FIELDLIST_DATA_HANDLER = FieldListDataHandler()
-handler = [FIELDLIST_DATA_HANDLER, FieldDataHandler()]
+handler = [FieldListDataHandler, FieldDataHandler]

--- a/src/earthkit/regrid/data/grib.py
+++ b/src/earthkit/regrid/data/grib.py
@@ -1,0 +1,46 @@
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import logging
+
+from .handler import DataHandler
+
+LOG = logging.getLogger(__name__)
+
+
+class GribMessageDataHandler(DataHandler):
+    @staticmethod
+    def match(values):
+        if isinstance(values, bytes):
+            return True
+        else:
+            from io import BytesIO
+
+            # TODO: add further checks to see if the object is a GRIB message
+            if isinstance(values, BytesIO):
+                return True
+        return False
+
+    def regrid(self, values, **kwargs):
+        backend = self.backend_from_kwargs(kwargs)
+        # backend = self.get_backend(kwargs.pop("backend"), matrix_source=kwargs.pop("matrix_source", None))
+        if hasattr(backend, "regrid_grib"):
+            if not isinstance(values, bytes):
+                from io import BytesIO
+
+                if isinstance(values, BytesIO):
+                    values = values.getvalue()
+
+            kwargs.pop("in_grid", None)
+            return backend.regrid_grib(values, **kwargs)
+        else:
+            raise ValueError(f"regrid() does not support GRIB message input for {backend=}!")
+
+
+handler = GribMessageDataHandler()

--- a/src/earthkit/regrid/data/grib.py
+++ b/src/earthkit/regrid/data/grib.py
@@ -43,4 +43,4 @@ class GribMessageDataHandler(DataHandler):
             raise ValueError(f"regrid() does not support GRIB message input for {backend=}!")
 
 
-handler = GribMessageDataHandler()
+handler = GribMessageDataHandler

--- a/src/earthkit/regrid/data/handler.py
+++ b/src/earthkit/regrid/data/handler.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import logging
+from abc import ABCMeta
+from abc import abstractmethod
+
+LOG = logging.getLogger(__name__)
+
+
+class DataHandler(metaclass=ABCMeta):
+    @abstractmethod
+    def regrid(self, values, **kwargs):
+        pass
+
+    def backend_from_kwargs(self, kwargs):
+        return self.get_backend(kwargs.pop("backend"), inventory_path=kwargs.pop("inventory_path", None))
+
+    def get_backend(self, backend, inventory_path=None):
+        from earthkit.regrid.backends import get_backend
+
+        if backend == "precomputed-local":
+            backend = get_backend(backend, path_or_url=inventory_path)
+        else:
+            if inventory_path:
+                raise ValueError(
+                    f"Cannot use inventory_path={inventory_path} with backend={backend}. "
+                    "Only available for backend='precomputed-local'."
+                )
+            backend = get_backend(backend)
+
+        if not backend:
+            raise ValueError(f"No backend={backend} found")
+
+        return backend

--- a/src/earthkit/regrid/data/numpy.py
+++ b/src/earthkit/regrid/data/numpy.py
@@ -28,4 +28,4 @@ class NumpyDataHandler(DataHandler):
         return backend.regrid(values, in_grid, out_grid, **kwargs)
 
 
-handler = NumpyDataHandler()
+handler = NumpyDataHandler

--- a/src/earthkit/regrid/data/numpy.py
+++ b/src/earthkit/regrid/data/numpy.py
@@ -1,0 +1,31 @@
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import logging
+
+from .handler import DataHandler
+
+LOG = logging.getLogger(__name__)
+
+
+class NumpyDataHandler(DataHandler):
+    @staticmethod
+    def match(values):
+        import numpy as np
+
+        return isinstance(values, np.ndarray)
+
+    def regrid(self, values, **kwargs):
+        in_grid = kwargs.pop("in_grid")
+        out_grid = kwargs.pop("out_grid")
+        backend = self.backend_from_kwargs(kwargs)
+        return backend.regrid(values, in_grid, out_grid, **kwargs)
+
+
+handler = NumpyDataHandler()

--- a/src/earthkit/regrid/data/xarray.py
+++ b/src/earthkit/regrid/data/xarray.py
@@ -1,0 +1,103 @@
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import functools
+import logging
+
+from .handler import DataHandler
+
+LOG = logging.getLogger(__name__)
+
+
+class XarrayDataHandler(DataHandler):
+    @staticmethod
+    def match(values):
+        from earthkit.regrid.utils import is_module_loaded
+
+        if not is_module_loaded("xarray"):
+            return False
+
+        try:
+            import xarray as xr
+
+            return isinstance(values, (xr.DataArray, xr.Dataset))
+        except Exception:
+            return False
+
+    def _find_dim_names(self, size):
+        match size:
+            case 1:
+                return ["values"]
+            case 2:
+                return ["latitude", "longitude"]
+            case _:
+                return None
+
+    def regrid(self, values, **kwargs):
+        from .numpy import NumpyDataHandler
+
+        # backend = self.backend_from_kwargs(kwargs)
+
+        in_grid = kwargs.pop("in_grid", None)
+        if in_grid is None:
+            in_grid = values.attrs.get("gridspec", None)
+            if in_grid is None and "earthkit" in values:
+                in_grid = values.earthkit.grid_spec
+
+        out_grid = kwargs.pop("out_grid")
+
+        import xarray as xr
+
+        assert in_grid is not None, "in_grid must be provided"
+        assert out_grid is not None, "out_grid must be provided"
+
+        shape = None
+        # _, shape = find(in_grid, out_grid, **kwargs)
+
+        default_in_dims = self._find_dim_names(len(values.dims))
+        if "in_dims" not in kwargs and default_in_dims is None:
+            raise ValueError(f"Unknown number of input dimensions: {len(values.dims)}")
+
+        in_dims = kwargs.pop("in_dims", default_in_dims)
+        in_dims = [in_dims] if not isinstance(in_dims, list) else in_dims
+
+        default_out_dims = self._find_dim_names(len(shape))
+        if "out_dims" not in kwargs and default_out_dims is None:
+            raise ValueError("Unknown number of output dimensions.")
+
+        out_dims = kwargs.pop("out_dims", default_out_dims)
+        out_dims = [out_dims] if not isinstance(out_dims, list) else out_dims
+
+        ds_out = xr.apply_ufunc(
+            functools.partial(NumpyDataHandler().regrid, in_grid=in_grid, out_grid=out_grid, **kwargs),
+            values,
+            input_core_dims=[in_dims],
+            output_core_dims=[out_dims],
+            vectorize=True,
+            dask="parallelized",
+            dask_gufunc_kwargs={
+                "output_sizes": {dim: shape[i] for i, dim in enumerate(out_dims)},
+                "allow_rechunk": True,
+            },
+            output_dtypes=[values.dtype],
+        )
+        # self.set_coords(ds_out, out_grid, **kwargs)
+        # ds_out.earthkit.set_grid(out_grid)
+
+        return ds_out
+
+    def set_coords(self, ds_out, out_grid, **kwargs):
+        import earthkit.geo as ekg
+
+        lat, lon = ekg.to_latlon(out_grid)
+        ds_out.coords["latitude"] = lat
+        ds_out.coords["longitude"] = lon
+
+
+handler = XarrayDataHandler()

--- a/src/earthkit/regrid/data/xarray.py
+++ b/src/earthkit/regrid/data/xarray.py
@@ -10,9 +10,195 @@
 import functools
 import logging
 
+from earthkit.regrid.utils import ensure_list
+
 from .handler import DataHandler
 
 LOG = logging.getLogger(__name__)
+
+
+# TODO: This is a temporary wrapper to use the grid interface
+class GridWrapper:
+    def __init__(self, grid_spec):
+        from mir import Grid
+
+        self._grid = Grid(**grid_spec)
+        self._grid_spec = grid_spec
+
+    def __getattr__(self, name):
+        return getattr(self._grid, name)
+
+    def to_latlons(self):
+        import numpy as np
+
+        lat, lon = self._grid.to_latlons()
+        return np.array(lat), np.array(lon)
+
+    @property
+    def grid_spec(self):
+        return self.spec
+
+    def is_spectral(self):
+        return False
+
+    def to_distinct_latlons(self, field_shape):
+        if len(self._grid.shape) == 2:
+            lat, lon = self.to_latlons()
+            lat = lat.reshape(self._grid.shape)
+            lon = lon.reshape(self._grid.shape)
+            d_lat = self._distinct_lats(lat)
+            if d_lat is not None:
+                d_lon = self._distinct_lons(lon)
+                if d_lon is not None and len(d_lat) == field_shape[0] and len(d_lon) == field_shape[1]:
+                    return d_lat, d_lon
+
+        return None, None
+
+    @staticmethod
+    def _distinct_lats(lats):
+        import numpy as np
+
+        assert len(lats.shape) == 2
+        rows = lats.shape[0]
+        r = np.ones(rows)
+        if rows > 0:
+            for i in range(rows):
+                vals = lats[i, :]
+                delta = np.diff(vals)
+                if np.allclose(delta, delta[0]):
+                    r[i] = vals[0]
+                else:
+                    return None
+            return r
+        return None
+
+    @staticmethod
+    def _distinct_lons(lons):
+        import numpy as np
+
+        assert len(lons.shape) == 2
+        cols = lons.shape[1]
+        r = np.ones(cols)
+        if cols > 0:
+            for i in range(cols):
+                vals = lons[:, i]
+                delta = np.diff(vals)
+                if np.allclose(delta, delta[0]):
+                    r[i] = vals[0]
+                else:
+                    return None
+            return r
+        return None
+
+
+class XarrrayGeographyBuilder:
+    def __init__(self, grid_spec):
+        self.grid = GridWrapper(grid_spec)
+        self.grid_spec = grid_spec
+
+    @property
+    def shape(self):
+        return self.grid.shape
+
+    def geo_dims(self):
+        """
+        Determine the geographical dimensions of the dataset.
+        """
+        num = len(self.shape)
+        if num >= 2:
+            return ["latitude", "longitude"]
+        if num == 1:
+            return ["values"]
+
+        raise ValueError("Geography is not supported.")
+
+    def coords(self):
+        import math
+
+        field_shape = self.grid.shape
+
+        coords = {}
+        dims = {}
+        coords_dim = {}
+
+        if self.grid.is_spectral():
+            if len(field_shape) == 1:
+                dims["values"] = field_shape[0]
+        else:
+            if len(field_shape) == 1:
+                dims["values"] = field_shape[0]
+                try:
+                    lat, lon = self.grid.to_latlons()
+                    if lat is not None and lon is not None:
+                        coords["latitude"] = lat
+                        coords["longitude"] = lon
+                        coords_dim = {k: ("values",) for k in coords}
+                except Exception:
+                    pass
+            elif len(field_shape) == 2:
+                try:
+                    lat, lon = self.grid.to_distinct_latlons(field_shape)
+                    if (
+                        lat is not None
+                        and lon is not None
+                        and len(lat) == field_shape[0]
+                        and len(lon) == field_shape[1]
+                    ):
+                        coords["latitude"] = lat
+                        coords["longitude"] = lon
+                        coords_dim["latitude"] = ("latitude",)
+                        coords_dim["longitude"] = ("longitude",)
+                        dims["latitude"] = lat.size
+                        dims["longitude"] = lon.size
+                        assert coords["latitude"].size == field_shape[0]
+                        assert coords["longitude"].size == field_shape[1]
+                        assert dims["latitude"] == field_shape[0]
+                        assert dims["longitude"] == field_shape[1]
+                except Exception as e:
+                    print(e)
+                    pass
+
+                if not coords or not dims:
+                    lat, lon = self.grid.to_latlons()
+                    # print("to_latlons:", type(lat), type(lon))
+                    if lat is not None and lon is not None:
+                        lat = lat.reshape(field_shape)
+                        lon = lon.reshape(field_shape)
+                        coords["latitude"] = lat
+                        coords["longitude"] = lon
+                        coords_dim = {k: ("y", "x") for k in coords}
+                        dims["y"] = field_shape[0]
+                        dims["x"] = field_shape[1]
+                        print("field_shape:", field_shape, lat.shape, lon.shape)
+                        assert coords["latitude"].shape == field_shape
+                        assert coords["longitude"].shape == field_shape
+            else:
+                raise ValueError(f"Unsupported field shape {field_shape}")
+
+        # if hasattr(field, "unload"):
+        #     field.unload()
+
+        for k, v in coords.items():
+            assert k in coords_dim, f"{k=}, {coords_dim=}"
+            assert all(x in dims for x in coords_dim[k]), f"{k=}, {coords_dim=} {dims=}"
+            assert v.size == math.prod([dims[x] for x in coords_dim[k]])
+
+        return dims, coords, coords_dim
+
+
+def xr_geo_dims(ds):
+    """
+    Determine the geographical dimensions of the dataset/dataarray.
+    """
+    dims = list(ds.sizes.keys())
+    if len(ds.dims) >= 1:
+        if dims[-1] == "values":
+            return ["values"]
+    if len(dims) >= 2:
+        if dims[-2] == "latitude" and dims[-1] == "longitude":
+            return ["latitude", "longitude"]
+
+    raise ValueError("Dataset geography is not supported.")
 
 
 class XarrayDataHandler(DataHandler):
@@ -30,74 +216,75 @@ class XarrayDataHandler(DataHandler):
         except Exception:
             return False
 
-    def _find_dim_names(self, size):
-        match size:
-            case 1:
-                return ["values"]
-            case 2:
-                return ["latitude", "longitude"]
-            case _:
-                return None
-
     def regrid(self, values, **kwargs):
         from .numpy import NumpyDataHandler
 
-        # backend = self.backend_from_kwargs(kwargs)
+        kwargs = kwargs.copy()
 
         in_grid = kwargs.pop("in_grid", None)
         if in_grid is None:
             in_grid = values.attrs.get("gridspec", None)
-            if in_grid is None and "earthkit" in values:
-                in_grid = values.earthkit.grid_spec
+            if in_grid is None:
+                try:
+                    in_grid = values.earthkit.grid_spec
+                except AttributeError:
+                    pass
+
+        if in_grid is None:
+            raise ValueError("in_grid must be provided")
+
+        in_grid = GridWrapper(in_grid)
 
         out_grid = kwargs.pop("out_grid")
+        if out_grid is None:
+            raise ValueError("out_grid must be provided")
+
+        out_geo = XarrrayGeographyBuilder(out_grid)
+
+        in_dims = kwargs.pop("in_dims", None)
+        if in_dims is None:
+            in_dims = xr_geo_dims(values)
+
+        if in_dims is None:
+            raise ValueError(f"Could not determine geography related input dimensions: {values.dims}")
+
+        out_dims = kwargs.pop("out_dims", None)
+        if out_dims is None:
+            out_dims = out_geo.geo_dims()
+
+        if out_dims is None:
+            raise ValueError(f"Could not determine geography related output dimensions: {values.dims}")
+
+        in_dims = ensure_list(in_dims)
+        out_dims = ensure_list(out_dims)
 
         import xarray as xr
 
-        assert in_grid is not None, "in_grid must be provided"
-        assert out_grid is not None, "out_grid must be provided"
-
-        shape = None
-        # _, shape = find(in_grid, out_grid, **kwargs)
-
-        default_in_dims = self._find_dim_names(len(values.dims))
-        if "in_dims" not in kwargs and default_in_dims is None:
-            raise ValueError(f"Unknown number of input dimensions: {len(values.dims)}")
-
-        in_dims = kwargs.pop("in_dims", default_in_dims)
-        in_dims = [in_dims] if not isinstance(in_dims, list) else in_dims
-
-        default_out_dims = self._find_dim_names(len(shape))
-        if "out_dims" not in kwargs and default_out_dims is None:
-            raise ValueError("Unknown number of output dimensions.")
-
-        out_dims = kwargs.pop("out_dims", default_out_dims)
-        out_dims = [out_dims] if not isinstance(out_dims, list) else out_dims
-
         ds_out = xr.apply_ufunc(
-            functools.partial(NumpyDataHandler().regrid, in_grid=in_grid, out_grid=out_grid, **kwargs),
+            functools.partial(
+                NumpyDataHandler().regrid,
+                in_grid=in_grid.grid_spec,
+                out_grid=out_geo.grid_spec,
+                output="values",
+                **kwargs,
+            ),
             values,
             input_core_dims=[in_dims],
             output_core_dims=[out_dims],
             vectorize=True,
             dask="parallelized",
             dask_gufunc_kwargs={
-                "output_sizes": {dim: shape[i] for i, dim in enumerate(out_dims)},
+                "output_sizes": {dim: out_geo.shape[i] for i, dim in enumerate(out_dims)},
                 "allow_rechunk": True,
             },
             output_dtypes=[values.dtype],
         )
-        # self.set_coords(ds_out, out_grid, **kwargs)
-        # ds_out.earthkit.set_grid(out_grid)
+
+        _, coords, _ = out_geo.coords()
+        for k, v in coords.items():
+            ds_out.coords[k] = v
 
         return ds_out
 
-    def set_coords(self, ds_out, out_grid, **kwargs):
-        import earthkit.geo as ekg
 
-        lat, lon = ekg.to_latlon(out_grid)
-        ds_out.coords["latitude"] = lat
-        ds_out.coords["longitude"] = lon
-
-
-handler = XarrayDataHandler()
+handler = XarrayDataHandler

--- a/src/earthkit/regrid/regrid.py
+++ b/src/earthkit/regrid/regrid.py
@@ -7,11 +7,10 @@
 # nor does it submit to any jurisdiction.
 #
 
-from .data import get_data_handler
-from warnings import warn
-
 
 def regrid(values, in_grid=None, out_grid=None, *, interpolation="linear", backend="mir", **kwargs):
+    from earthkit.regrid.data import get_data_handler
+
     h = get_data_handler(values)
     if h is None:
         raise ValueError(f"Cannot regrid data with type={type(values)}")

--- a/src/earthkit/regrid/regrid.py
+++ b/src/earthkit/regrid/regrid.py
@@ -8,6 +8,7 @@
 #
 
 from .data import get_data_handler
+from warnings import warn
 
 
 def regrid(values, in_grid=None, out_grid=None, *, interpolation="linear", backend="mir", **kwargs):

--- a/src/earthkit/regrid/utils/__init__.py
+++ b/src/earthkit/regrid/utils/__init__.py
@@ -64,3 +64,13 @@ def no_progress_bar(total, initial=0, desc=None):
 
 def is_module_loaded(module_name):
     return module_name in sys.modules
+
+
+def ensure_list(obj):
+    """Ensure that the input is a list."""
+    if isinstance(obj, list):
+        return obj
+    elif isinstance(obj, tuple):
+        return list(obj)
+    else:
+        return [obj]

--- a/src/earthkit/regrid/utils/testing.py
+++ b/src/earthkit/regrid/utils/testing.py
@@ -9,6 +9,8 @@
 import os
 from importlib import import_module
 
+import numpy as np
+
 PATH = os.path.dirname(__file__)
 
 URL_ROOT = "https://get.ecmwf.int/repository/test-data/earthkit-regrid/test-data"
@@ -96,3 +98,64 @@ def compare_global_ll_results(v_res, v_ref, interpolation, **kwargs):
         np.testing.assert_allclose(v_res[1:-1].flatten(), v_ref[1:-1].flatten(), verbose=False, **kwargs)
     else:
         np.testing.assert_allclose(v_res.flatten(), v_ref.flatten(), verbose=False, **kwargs)
+
+
+def compare_dims(ds, ref_coords, order_ref_var=None, sizes=False):
+    compare_dim_order(ds, ref_coords, order_ref_var=order_ref_var)
+    if not sizes:
+        for k, v in ref_coords.items():
+            compare_coord(ds, k, v, mode="dim")
+    else:
+        compare_dim_size(ds, ref_coords)
+
+
+def compare_coords(ds, ref_coords):
+    for k, v in ref_coords.items():
+        compare_coord(ds, k, v, mode="coord")
+
+
+def compare_coord(ds, name, ref_vals, mode="coord"):
+    assert name in ds.coords, f"{name=} not in {ds.coords}"
+    if mode == "dim":
+        assert name in ds.sizes, f"{name=} not in {ds.sizes}"
+        assert ds.sizes[name] == len(ref_vals), f"{name=} {ds.sizes[name]} != {len(ref_vals)}"
+
+    vals = ds.coords[name].values
+    if isinstance(ref_vals[0], str):
+        assert vals.tolist() == ref_vals, f"{name=} {vals.tolist()} != {ref_vals}"
+    else:
+        vals = np.asarray(vals).flatten()
+        ref_vals = np.asarray(ref_vals).flatten()
+
+        assert vals.shape == ref_vals.shape, f"{name=} {vals.shape} != {ref_vals.shape}"
+        # datetime/timedelta 64
+        if np.issubdtype(vals.dtype, np.datetime64) or np.issubdtype(vals.dtype, np.timedelta64):
+            for i in range(len(ref_vals)):
+                assert vals[i] == ref_vals[i], f"{name=} {vals[i]} != {ref_vals[i]}"
+        # other arrays
+        else:
+            assert np.allclose(ds.coords[name].values, vals), f"{name=} {ds.coords[name].values} != {vals}"
+
+
+def compare_dim_order(ds, dims, order_ref_var, check_coord=True):
+    if order_ref_var is None:
+        return
+
+    dim_order = []
+
+    for d in ds[order_ref_var].dims:
+        if d in dims:
+            dim_order.append(d)
+            if check_coord:
+                assert d in ds.coords, f"{d} not in {ds.coords}"
+
+    if isinstance(dims, dict):
+        assert dim_order == list(dims.keys()), f"{dim_order=} != {list(dims.keys())}"
+    else:
+        assert dim_order == dims, f"{dim_order=} != {dims}"
+
+
+def compare_dim_size(ds, dims):
+    for name, v in dims.items():
+        assert name in ds.sizes, f"{name=} not in {ds.sizes}"
+        assert ds.sizes[name] == v, f"{name=} {ds.sizes[name]} != {v}"

--- a/tests/regrid_backends/test_matrix_xarray.py
+++ b/tests/regrid_backends/test_matrix_xarray.py
@@ -1,0 +1,13 @@
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from earthkit.regrid.utils.testing import NO_EKD  # noqa: E402
+
+if not NO_EKD:
+    from earthkit.data import from_source  # noqa

--- a/tests/regrid_backends/test_matrix_xarray.py
+++ b/tests/regrid_backends/test_matrix_xarray.py
@@ -11,6 +11,7 @@ import pytest
 
 from earthkit.regrid import regrid
 from earthkit.regrid.utils.testing import NO_EKD  # noqa: E402
+from earthkit.regrid.utils.testing import NO_MIR  # noqa: E402
 from earthkit.regrid.utils.testing import compare_dims
 
 if not NO_EKD:
@@ -18,6 +19,7 @@ if not NO_EKD:
 
 
 @pytest.mark.skipif(NO_EKD, reason="No earthkit.data available")
+@pytest.mark.skipif(NO_MIR, reason="No mir available")
 @pytest.mark.parametrize(
     "out_grid,dims",
     [
@@ -36,6 +38,7 @@ def test_regrid_matrix_xarray_from_ogg(out_grid, dims):
 
 
 @pytest.mark.skipif(NO_EKD, reason="No earthkit.data available")
+@pytest.mark.skipif(NO_MIR, reason="No mir available")
 @pytest.mark.parametrize(
     "out_grid,dims",
     [

--- a/tests/regrid_mir/test_regrid_xarray.py
+++ b/tests/regrid_mir/test_regrid_xarray.py
@@ -55,3 +55,20 @@ def test_regrid_xarray_from_h_nested(out_grid, dims):
     r = regrid(ds["2t"], out_grid=out_grid, interpolation="linear")
 
     compare_dims(r, dims, sizes=True)
+
+
+@pytest.mark.skipif(NO_MIR, reason="No mir available")
+@pytest.mark.skipif(NO_EKD, reason="No earthkit.data available")
+@pytest.mark.parametrize(
+    "out_grid,dims",
+    REFS,
+)
+def test_regrid_xarray_dataset_from_h_nested(out_grid, dims):
+
+    ds_in = from_source("sample", "H8_nested_t2.grib2")
+    assert len(ds_in) == 2
+    ds = ds_in.to_xarray()
+
+    r = regrid(ds, out_grid=out_grid, interpolation="linear")
+
+    compare_dims(r, dims, sizes=True)

--- a/tests/regrid_mir/test_regrid_xarray.py
+++ b/tests/regrid_mir/test_regrid_xarray.py
@@ -11,43 +11,47 @@ import pytest
 
 from earthkit.regrid import regrid
 from earthkit.regrid.utils.testing import NO_EKD  # noqa: E402
+from earthkit.regrid.utils.testing import NO_MIR  # noqa: E402
 from earthkit.regrid.utils.testing import compare_dims
 
 if not NO_EKD:
     from earthkit.data import from_source  # noqa
 
 
+REFS = [
+    ({"grid": [10, 10]}, {"step": 2, "latitude": 19, "longitude": 36}),
+    ({"grid": "N32"}, {"step": 2, "values": 6114}),
+    ({"grid": "H4", "order": "nested"}, {"step": 2, "values": 192}),
+    ({"grid": "H4", "order": "ring"}, {"step": 2, "values": 192}),
+]
+
+
+@pytest.mark.skipif(NO_MIR, reason="No mir available")
 @pytest.mark.skipif(NO_EKD, reason="No earthkit.data available")
-@pytest.mark.parametrize(
-    "out_grid,dims",
-    [
-        ({"grid": [10, 10]}, {"step": 2, "latitude": 19, "longitude": 36}),
-    ],
-)
-def test_regrid_matrix_xarray_from_ogg(out_grid, dims):
+@pytest.mark.parametrize("out_grid,dims", REFS)
+def test_regrid_xarray_from_ogg(out_grid, dims):
 
     ds_in = from_source("sample", "O32_t2.grib2")
     assert len(ds_in) == 2
     ds = ds_in.to_xarray()
 
-    r = regrid(ds["2t"], out_grid=out_grid, interpolation="linear", backend="precomputed")
+    r = regrid(ds["2t"], out_grid=out_grid, interpolation="linear")
 
     compare_dims(r, dims, sizes=True)
 
 
+@pytest.mark.skipif(NO_MIR, reason="No mir available")
 @pytest.mark.skipif(NO_EKD, reason="No earthkit.data available")
 @pytest.mark.parametrize(
     "out_grid,dims",
-    [
-        ({"grid": [10, 10]}, {"step": 2, "latitude": 19, "longitude": 36}),
-    ],
+    REFS,
 )
-def test_regrid_matrix_xarray_from_h_nested(out_grid, dims):
+def test_regrid_xarray_from_h_nested(out_grid, dims):
 
     ds_in = from_source("sample", "H8_nested_t2.grib2")
     assert len(ds_in) == 2
     ds = ds_in.to_xarray()
 
-    r = regrid(ds["2t"], out_grid=out_grid, interpolation="linear", backend="precomputed")
+    r = regrid(ds["2t"], out_grid=out_grid, interpolation="linear")
 
     compare_dims(r, dims, sizes=True)


### PR DESCRIPTION
### Description

This PR enables to use Xarray input in `regrid()`.

- works for Xarray generated from GRIB data with earthkit
- works for dataarrays/datasets
- works for all the regrid backends
- tested for global regular lat-lon, reduced Gaussian and HEALPix grids (input/output)
- the resulting Xarray contains the correct lat-lon values

TODO (in separate PRs):
 - add more tests
 - add subarea support

A working example:

```python
from earthkit.regrid import regrid
import earthkit.data as ekd

# Get octahedral reduced Gaussian GRIB data containing two fields.
ds_in = ekd.from_source("sample", "O32_t2.grib2")
ds = ds_in.to_xarray()
out_grid = {"grid": "N32"}
r = regrid(ds, out_grid=out_grid, interpolation="linear")
```

<img width="311" height="188" alt="image" src="https://github.com/user-attachments/assets/955d0e6f-82d5-4ce9-817c-af4fff712012" />


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 