### PR TITLE
Regridding with rasterio.warp.reproject and a new GridSpec that combines a CRS, affine transformation and shape

### DIFF
--- a/src/earthkit/regrid/backends/rasterio.py
+++ b/src/earthkit/regrid/backends/rasterio.py
@@ -60,7 +60,7 @@ class CRSAffineGridSpec:
             Coordinate reference system.
         affine : affine.Affine
             Affine transformation matrix mapping array coordinates (indices)
-            to world coordinates.
+            to CRS coordinates.
         shape : tuple[int, int]
             Number of grid points in y and x directions (array order).
         """
@@ -75,7 +75,7 @@ class CRSAffineGridSpec:
         crs : rasterio.crs.CRS
             Coordinate reference system.
         bounds : tuple[number, number, number, number]
-            Bounding coordinates of the grid in world coordinates. Order is
+            Bounding coordinates of the grid in CRS coordinates. Order is
             left, bottom, right, top. References grid boxes, grid points are
             generated at the center of the boxes.
         shape : tuple[int, int]
@@ -101,7 +101,7 @@ class CRSAffineGridSpec:
         crs : rasterio.crs.CRS
             Coordinate reference system.
         bounds : tuple[number, number, number, number]
-            Bounding coordinates of the grid in world coordinates. Order is
+            Bounding coordinates of the grid in CRS coordinates. Order is
             left, bottom, right, top. References grid boxes, grid points are
             generated at the center of the boxes.
         resolution : tuple[number, number] | number
@@ -119,7 +119,7 @@ class CRSAffineGridSpec:
 
     @classmethod
     def from_regular_coords(cls, crs, x, y):
-        """Grid from a CRS and sequences of world coordinates.
+        """Grid from a CRS and sequences of CRS coordinates.
 
         Coordinates must form a regular grid.
 
@@ -128,10 +128,10 @@ class CRSAffineGridSpec:
         crs : rasterio.crs.CRS
             Coordinate reference system.
         x : sequence
-            World coordinates of the grid points (=grid box centers) in the
+            CRS coordinates of the grid points (=grid box centers) in the
             x direction.
         y : sequence
-            World coordinates of the grid points (=grid box centers) in the
+            CRS coordinates of the grid points (=grid box centers) in the
             y direction.
         """
         shape = (len(y), len(x))
@@ -168,7 +168,7 @@ class CRSAffineGridSpec:
 
     @property
     def bounds(self):
-        """World coordinates of bounding box (left, bottom, top, right).
+        """CRS coordinates of bounding box (left, bottom, top, right).
 
         Outer coordinates, including all grid boxes, with grid points at the
         center of the grid boxes.
@@ -181,7 +181,7 @@ class CRSAffineGridSpec:
 
     @property
     def xy_coords(self):
-        """World coordinates of all grid points."""
+        """CRS coordinates of all grid points."""
         gridx = np.arange(self.nx) + 0.5
         gridy = np.arange(self.ny) + 0.5
         return self.transform * np.meshgrid(gridx, gridy)

--- a/src/earthkit/regrid/backends/rasterio.py
+++ b/src/earthkit/regrid/backends/rasterio.py
@@ -7,30 +7,279 @@
 # nor does it submit to any jurisdiction.
 #
 
+from collections.abc import Iterable
+
+import numpy as np
+
 from . import Backend
 
 
+def _resolution(shape, bounds, outer=True):
+    # Based on: rioxarray.rioxarray.XRasterBase.resolution
+    ny, nx = shape
+    left, bottom, right, top = bounds
+    dx = (right - left) / (nx - (0 if outer else 1))
+    dy = (bottom - top) / (ny - (0 if outer else 1))
+    return dx, dy
+
+
+def _as_outer_bounds(bounds, shape):
+    # Based on: rioxarray.rioxarray.XRasterBase._unordered_bounds
+    dx, dy = _resolution(shape, bounds, outer=False)
+    left, bottom, right, top = bounds
+    return (
+        left - 0.5 * dx,
+        bottom + 0.5 * dy,
+        right + 0.5 * dx,
+        top - 0.5 * dy,
+    )
+
+
+def _has_rotation(affine):
+    # Based on: rioxarray.rioxarray._affine_has_rotation
+    return affine.b == affine.d != 0
+
+
+class CRSAffineGridSpec:
+    """Affine transformation mapping into a coordinate reference system."""
+
+    # TODO: serialisation
+
+    def __init__(self, crs, transform, shape):
+        self.crs = crs
+        self.transform = transform
+        self.shape = shape  # array order (y, x)
+
+    @classmethod
+    def from_affine(cls, crs, affine, shape):
+        """Grid fom a CRS, affine projection and shape.
+
+        Parameters
+        ----------
+        crs : rasterio.crs.CRS
+            Coordinate reference system.
+        affine : affine.Affine
+            Affine transformation matrix mapping array coordinates (indices)
+            to world coordinates.
+        shape : tuple[int, int]
+            Number of grid points in y and x directions (array order).
+        """
+        return cls(crs, affine, shape)
+
+    @classmethod
+    def from_shape(cls, crs, bounds, shape):
+        """Grid from a CRS, bounding box and shape.
+
+        Parameters
+        ----------
+        crs : rasterio.crs.CRS
+            Coordinate reference system.
+        bounds : tuple[number, number, number, number]
+            Bounding coordinates of the grid in world coordinates. Order is
+            left, bottom, right, top. References grid boxes, grid points are
+            generated at the center of the boxes.
+        shape : tuple[int, int]
+            Number of grid points in y and x directions (array order).
+        """
+        from affine import Affine
+
+        left, _, _, top = bounds  # reference corner
+        dx, dy = _resolution(shape, bounds, outer=True)
+        affine = Affine.translation(left, top) * Affine.scale(dx, dy)
+        return cls(crs, affine, shape)
+
+    @classmethod
+    def from_resolution(cls, crs, bounds, resolution):
+        """Grid from a CRS, bounding box and target resolution.
+
+        The returned grid will map to the given bounds exactly by adjusting
+        the resolution to match the requirements of a regular grid with an
+        integer number of grid points in each dimension.
+
+        Parameters
+        ----------
+        crs : rasterio.crs.CRS
+            Coordinate reference system.
+        bounds : tuple[number, number, number, number]
+            Bounding coordinates of the grid in world coordinates. Order is
+            left, bottom, right, top. References grid boxes, grid points are
+            generated at the center of the boxes.
+        resolution : tuple[number, number] | number
+            Grid spacing in x and y direction (coordinate order).
+        """
+        left, bottom, right, top = bounds
+        if isinstance(resolution, Iterable):
+            dx, dy = resolution
+        else:
+            dx = resolution
+            dy = resolution
+        nx = int(abs((right - left) / dx))
+        ny = int(abs((top - bottom) / dy))
+        return cls.from_shape(crs, bounds, (ny, nx))
+
+    @classmethod
+    def from_regular_coords(cls, crs, x, y):
+        """Grid from a CRS and sequences of world coordinates.
+
+        Coordinates must form a regular grid.
+
+        Parameters
+        ----------
+        crs : rasterio.crs.CRS
+            Coordinate reference system.
+        x : sequence
+            World coordinates of the grid points (=grid box centers) in the
+            x direction.
+        y : sequence
+            World coordinates of the grid points (=grid box centers) in the
+            y direction.
+        """
+        shape = (len(y), len(x))
+        # Assumption: grid point coordinates at center of cells
+        bounds = _as_outer_bounds((x[0], y[-1], x[-1], y[0]), shape)
+        return cls.from_shape(crs, bounds, shape)
+
+    @classmethod
+    def from_rioxarray(cls, da):
+        """Reproduce the grid of a rioxarray-compatible dataarray"""
+        return cls(da.rio.crs, da.rio.transform(), da.rio.shape)
+
+    @property
+    def nx(self):
+        """Number of grid points in x direction."""
+        return self.shape[1]
+
+    @property
+    def ny(self):
+        """Number of grid points in y direction."""
+        return self.shape[0]
+
+    @property
+    def resolution(self):
+        """Grid spacing in x and y direction (coordinate order)."""
+        # Based on: rioxarray.rioxarray._resolution
+        # Preserve sign if transform doesn't rotate
+        if not _has_rotation(self.transform):
+            return self.transform.a, self.transform.e  # dx, dy
+        return (
+            np.sqrt(self.transform.a**2 + self.transform.d**2),  # dx
+            np.sqrt(self.transform.b**2 + self.transform.e**2),  # dy
+        )
+
+    @property
+    def bounds(self):
+        """World coordinates of bounding box (left, bottom, top, right).
+
+        Outer coordinates, including all grid boxes, with grid points at the
+        center of the grid boxes.
+        """
+        # Based on: rioxarray.rioxarray.XRasterBase.bounds
+        dx, dy = self.resolution
+        xs = [self.transform.c, self.transform.c + dx * self.nx]
+        ys = [self.transform.f, self.transform.f + dy * self.ny]
+        return min(xs), min(ys), max(xs), max(ys)
+
+    @property
+    def xy_coords(self):
+        """World coordinates of all grid points."""
+        gridx = np.arange(self.nx) + 0.5
+        gridy = np.arange(self.ny) + 0.5
+        return self.transform * np.meshgrid(gridx, gridy)
+
+    def reproject(self, crs, *, shape=None, resolution=None):
+        """Default grid resulting from reprojection with rasterio.
+
+        Requires rasterio.warp.calculate_default_transform.
+
+        Parameters
+        ----------
+        crs : rasterio.crs.CRS
+            Target CRS for the reprojection.
+        shape : None | tuple[int, int], optional
+            Number of output grid points in y and x directions (array order).
+            Cannot be used together with resolution.
+        resolution : None | tuple[]
+            Grid spacing of output grid in x and y directions (coordinate
+            order). Cannot be used together with shape.
+        """
+        from rasterio.warp import calculate_default_transform
+
+        assert shape is None or resolution is None, "shape and resolution are mutually exclusive"
+        kwargs = {}
+        if shape is not None:
+            kwargs["dst_height"], kwargs["dst_width"] = shape
+        if resolution is not None:
+            kwargs["resolution"] = resolution
+
+        transform, nx, ny = calculate_default_transform(
+            self.crs, crs, self.nx, self.ny, *self.bounds, **kwargs
+        )
+        return type(self)(crs, transform, (ny, nx))
+
+
+def to_rasterio_kwargs(gs, nodata, prefix=""):
+    return {f"{prefix}crs": gs.crs, f"{prefix}transform": gs.transform, f"{prefix}nodata": nodata}
+
+
 class RasterioBackend(Backend):
+    """Regridding with rasterio.warp.reproject."""
 
     name = "rasterio"
 
-    def regrid(self, values, in_grid, out_grid, resampling=None, **kwargs):
+    def regrid(self, values, in_grid, out_grid, interpolation=None, nodata=None):
+        """Regrid with rasterio.warp.reproject.
+
+        Parameters
+        ----------
+        values : numpy.ndarray
+            Input values. Last axes must correspond to y and x dimensions.
+        in_grid : GridSpec
+            Grid specification for input values.
+        out_grid : GridSpec
+            Target grid specification.
+        interpolation : None | str
+            Resampling method. Choose from available names in rasterio.enums.Resampling.
+            The default resampling scheme of rasterio is nearest.
+        nodata : None | number
+            Nodata value for source and target values.
+
+        Returns
+        -------
+        numpy.ndarray
+            Regridded values.
+        """
         from rasterio.enums import Resampling
         from rasterio.warp import reproject
 
-        print("RASTERIO_REGRID kwargs", kwargs)
-        reproject_kwargs = {"src_crs": in_grid, "dst_crs": out_grid}
+        assert isinstance(in_grid, CRSAffineGridSpec)
+        # Convenience offered by rasterio: determine transform and shape
+        # of output grid based only on input grid and an output CRS.
+        # TODO: (how to) return the output GridSpec?
+        if not isinstance(out_grid, CRSAffineGridSpec):
+            out_grid = in_grid.reproject(out_grid)
 
-        # TODO: by default an "interpolation" kwarg is provided and set to "linear" by default
-        #       linear is "bilinear" in rasterio and not the default that rasterio users are
-        #       used to (nearest is default in rasterio)
-        if resampling is not None:
-            reproject_kwargs["resampling"] = Resampling[resampling]
+        assert in_grid.shape == values.shape[-2:], "in_grid does not match shape of values"
 
-        # TODO: go through kwargs and apply valid ones (default interpolation can be just handed over)
+        reproject_kwargs = {
+            **to_rasterio_kwargs(in_grid, nodata, prefix="src_"),
+            **to_rasterio_kwargs(out_grid, nodata, prefix="dst_"),
+        }
 
-        print(reproject_kwargs)
-        return reproject(source=values, **reproject_kwargs)
+        if interpolation is not None:
+            # Alias to accomodate regrid default
+            if interpolation == "linear":
+                interpolation = "bilinear"
+            reproject_kwargs["resampling"] = Resampling[interpolation]
+
+        # Flatten leading dimensions and restore after reprojection
+        # (rasterio only handles 2- and 3-dimensional arrays)
+        extra_shape = values.shape[:-2]
+        flat_size = np.prod(extra_shape, dtype=int)
+        print(extra_shape, flat_size)
+        values = values.reshape((flat_size, *in_grid.shape[-2:]))
+        regridded = np.empty((flat_size, *out_grid.shape), dtype=values.dtype)
+        reproject(source=values, destination=regridded, **reproject_kwargs)
+        return regridded.reshape((*extra_shape, *out_grid.shape))
 
 
 backend = RasterioBackend

--- a/src/earthkit/regrid/backends/rasterio.py
+++ b/src/earthkit/regrid/backends/rasterio.py
@@ -275,7 +275,6 @@ class RasterioBackend(Backend):
         # (rasterio only handles 2- and 3-dimensional arrays)
         extra_shape = values.shape[:-2]
         flat_size = np.prod(extra_shape, dtype=int)
-        print(extra_shape, flat_size)
         values = values.reshape((flat_size, *in_grid.shape[-2:]))
         regridded = np.empty((flat_size, *out_grid.shape), dtype=values.dtype)
         reproject(source=values, destination=regridded, **reproject_kwargs)

--- a/src/earthkit/regrid/backends/rasterio.py
+++ b/src/earthkit/regrid/backends/rasterio.py
@@ -1,0 +1,36 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+from . import Backend
+
+
+class RasterioBackend(Backend):
+
+    name = "rasterio"
+
+    def regrid(self, values, in_grid, out_grid, resampling=None, **kwargs):
+        from rasterio.enums import Resampling
+        from rasterio.warp import reproject
+
+        print("RASTERIO_REGRID kwargs", kwargs)
+        reproject_kwargs = {"src_crs": in_grid, "dst_crs": out_grid}
+
+        # TODO: by default an "interpolation" kwarg is provided and set to "linear" by default
+        #       linear is "bilinear" in rasterio and not the default that rasterio users are
+        #       used to (nearest is default in rasterio)
+        if resampling is not None:
+            reproject_kwargs["resampling"] = Resampling[resampling]
+
+        # TODO: go through kwargs and apply valid ones (default interpolation can be just handed over)
+
+        print(reproject_kwargs)
+        return reproject(source=values, **reproject_kwargs)
+
+
+backend = RasterioBackend


### PR DESCRIPTION
### Description

The regrid backend is a straightforward wrapper of `rasterio.warp.reproject`. The work is primarily in defining a compatible GridSpec and I'm opening the pull request as a draft to discuss its definition. I am proposing:

A new `CRSAffineGridSpec` class (for now defined together in the same file as the rasterio backend; to be moved), that follows the way rasterio defines (horizontal) grids and combines

1. a coordinate reference system as defined in `rasterio.crs.CRS`,
2. an affine transformation matrix (from rasterio's `affine` package) that maps array indices to CRS coordinates and
3. the shape of the grid.

For convenience, multiple constructors for a `CRSAffineGridSpec` are provided.


### A quick example

```python
import numpy as np
import rioxarray as rxr
import matplotlib.pyplot as plt

from earthkit.regrid.array import regrid
from earthkit.regrid.backends.rasterio import CRSAffineGridSpec  # temporary location

tif = rxr.open_rasterio(
    "https://raw.githubusercontent.com/ecmwf/earthkit-data/refs/heads/develop/tests/data/dgm50hs_col_32_368_5616_nw.tif",
    mask_and_scale=True
)

# The original CRS is EPSG:25832 (unit: metre)
in_grid = CRSAffineGridSpec.from_rioxarray(tif)

# Define a lat-lon grid for regridding to
out_grid = CRSAffineGridSpec.from_regular_coords(
    crs="EPSG:4326",
    x=np.linspace(7.1, 7.4, 101),  # °E
    y=np.linspace(50.65, 50.85, 101)  # °N
)

regridded = regrid(tif.values, in_grid=in_grid, out_grid=out_grid, backend="rasterio", interpolation="cubic", nodata=np.nan)

plt.pcolormesh(*out_grid.xy_coords, regridded[0])
```
<img width="587" height="416" alt="image" src="https://github.com/user-attachments/assets/51423fd3-5ca2-4683-937f-a4e3c9e96e46" />


### Not yet implemented

- Compatibility with the existing gridspecs (at least those that can be represented in rasterio-world; e.g. an LLGridSpec can be translated into a EPSG:4326-based grid).
- Integration with the non-array `regrid` function.
- Serialisation of CRSAffineGridSpec objects.
- Some data validation checks on initialisation of the CRSAffineGridSpec.
- Unit tests. None are included yet and I've only tested with the file from the example so far.

There are more possibilities to define a grid in rasterio (e.g., using ground control points) that are not covered by the prototype GridSpec but could also be considered.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 